### PR TITLE
Add `pywin32` and apply platform constants

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest==6.2.2 ; python_version <= "3.9"
 pytest==7.1.2 ; python_version >= "3.10"
 pyyaml==5.4
 requests>=2.23.0
-pywin32>=305
+pywin32>=305; sys_platform == "win32"
 setuptools>=56.0.0
 lockfile>=0.10
 urllib3<1.27,>=1.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pytest==6.2.2 ; python_version <= "3.9"
 pytest==7.1.2 ; python_version >= "3.10"
 pyyaml==5.4
 requests>=2.23.0
+pywin32>=305
 setuptools>=56.0.0
 lockfile>=0.10
 urllib3<1.27,>=1.26.2

--- a/src/wazuh_testing/constants/paths/__init__.py
+++ b/src/wazuh_testing/constants/paths/__init__.py
@@ -4,12 +4,14 @@
 import sys
 import os
 
+from wazuh_testing.constants.platforms import MACOS, WINDOWS
 
-if sys.platform == 'win32':
+
+if sys.platform == WINDOWS:
     WAZUH_PATH = os.path.join("C:", os.sep, "Program Files (x86)", "ossec-agent")
     ROOT_PREFIX = os.path.join('c:', os.sep)
 
-elif sys.platform == 'darwin':
+elif sys.platform == MACOS:
     WAZUH_PATH = os.path.join("/", "Library", "Ossec")
     ROOT_PREFIX = os.path.join('/', 'private', 'var', 'root')
 

--- a/src/wazuh_testing/constants/paths/binaries.py
+++ b/src/wazuh_testing/constants/paths/binaries.py
@@ -4,9 +4,11 @@
 import os
 import sys
 
+from psutil import WINDOWS
+
 from . import WAZUH_PATH
 
-if sys.platform == 'win32':
+if sys.platform == WINDOWS:
     BIN_PATH = WAZUH_PATH
 else:
     BIN_PATH = os.path.join(WAZUH_PATH, 'bin')

--- a/src/wazuh_testing/constants/paths/binaries.py
+++ b/src/wazuh_testing/constants/paths/binaries.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-from psutil import WINDOWS
+from wazuh_testing.constants.platforms import WINDOWS
 
 from . import WAZUH_PATH
 

--- a/src/wazuh_testing/constants/paths/configurations.py
+++ b/src/wazuh_testing/constants/paths/configurations.py
@@ -4,10 +4,12 @@
 import os
 import sys
 
+from wazuh_testing.constants.platforms import WINDOWS
+
 from . import WAZUH_PATH
 
 
-if sys.platform == 'win32':
+if sys.platform == WINDOWS:
     BASE_CONF_PATH = WAZUH_PATH
 else:
     BASE_CONF_PATH = os.path.join(WAZUH_PATH, 'etc')

--- a/src/wazuh_testing/constants/paths/logs.py
+++ b/src/wazuh_testing/constants/paths/logs.py
@@ -4,12 +4,14 @@
 import os
 import sys
 
+from wazuh_testing.constants.platforms import WINDOWS
+
 from . import WAZUH_PATH
 
 
 BASE_LOGS_PATH = os.path.join(WAZUH_PATH, 'logs')
 
-if sys.platform == 'win32':
+if sys.platform == WINDOWS:
     BASE_LOGS_PATH = WAZUH_PATH
     ACTIVE_RESPONSE_LOG_PATH = os.path.join(BASE_LOGS_PATH, 'active-response', 'active-responses.log')
 else:

--- a/src/wazuh_testing/constants/paths/variables.py
+++ b/src/wazuh_testing/constants/paths/variables.py
@@ -4,6 +4,8 @@
 import os
 import sys
 
+from psutil import WINDOWS
+
 from . import WAZUH_PATH
 
 
@@ -12,7 +14,7 @@ VAR_RUN_PATH = os.path.join(VAR_PATH, 'run')
 
 ANALYSISD_STATE = os.path.join(VAR_RUN_PATH, 'wazuh-analysisd.state')
 
-if sys.platform == 'win32':
+if sys.platform == WINDOWS:
     VERSION_FILE = os.path.join(WAZUH_PATH, 'VERSION')
 else:
     VERSION_FILE = ''

--- a/src/wazuh_testing/constants/paths/variables.py
+++ b/src/wazuh_testing/constants/paths/variables.py
@@ -4,7 +4,7 @@
 import os
 import sys
 
-from psutil import WINDOWS
+from wazuh_testing.constants.platforms import WINDOWS
 
 from . import WAZUH_PATH
 

--- a/src/wazuh_testing/global_parameters.py
+++ b/src/wazuh_testing/global_parameters.py
@@ -5,14 +5,16 @@ import sys
 
 from collections import defaultdict
 
+from wazuh_testing.constants.platforms import LINUX, MACOS
+
 
 class GlobalParameters:
     """Class to allocate all global parameters for testing"""
 
     def __init__(self):
         timeouts = defaultdict(lambda: 10)
-        timeouts['linux'] = 5
-        timeouts['darwin'] = 5
+        timeouts[LINUX] = 5
+        timeouts[MACOS] = 5
         self._default_timeout = timeouts[sys.platform]
 
     @property

--- a/src/wazuh_testing/global_parameters.py
+++ b/src/wazuh_testing/global_parameters.py
@@ -5,7 +5,7 @@ import sys
 
 from collections import defaultdict
 
-from wazuh_testing.constants.platforms import LINUX, MACOS
+from wazuh_testing.constants.platforms import LINUX, MACOS, WINDOWS
 
 
 class GlobalParameters:
@@ -15,6 +15,7 @@ class GlobalParameters:
         timeouts = defaultdict(lambda: 10)
         timeouts[LINUX] = 5
         timeouts[MACOS] = 5
+        timeouts[WINDOWS] = 60
         self._default_timeout = timeouts[sys.platform]
 
     @property

--- a/src/wazuh_testing/modules/analysisd/utils.py
+++ b/src/wazuh_testing/modules/analysisd/utils.py
@@ -12,6 +12,7 @@ from wazuh_testing import DATA_PATH
 from wazuh_testing.constants.keys.alerts import *
 from wazuh_testing.constants.keys.events import *
 from wazuh_testing.constants.paths.variables import ANALYSISD_STATE
+from wazuh_testing.constants.platforms import LINUX, WINDOWS
 
 
 with open(os.path.join(DATA_PATH, 'analysis_alert.json'), 'r') as f:
@@ -21,21 +22,21 @@ with open(os.path.join(DATA_PATH, 'analysis_alert_windows.json'), 'r') as f:
     win32_schema = json.load(f)
 
 
-def validate_analysis_alert(alert, schema='linux'):
+def validate_analysis_alert(alert, schema=LINUX):
     """Check if an Analysis event is properly formatted.
 
     Args:
         alert (dict): Dictionary that represent an alert
         schema (str, optional): String with the platform to validate the alert from. Default `linux`
     """
-    if schema == 'win32':
+    if schema == WINDOWS:
         _schema = win32_schema
     else:
         _schema = linux_schema
     validate(schema=_schema, instance=alert)
 
 
-def validate_analysis_alert_syscheck(alert, event, schema='linux'):
+def validate_analysis_alert_syscheck(alert, event, schema=LINUX):
     """Check if an Analysis alert is properly formatted in reference to its Syscheck event.
 
     Args:
@@ -48,7 +49,7 @@ def validate_analysis_alert_syscheck(alert, event, schema='linux'):
         for attribute, value in syscheck_event[SYSCHECK_DATA][event_field].items():
             # Skip certain attributes since their alerts will not have them
             if attribute in [SYSCHECK_ATTRIBUTES_TYPE, SYSCHECK_ATTRIBUTES_CHECKSUM, SYSCHECK_ATTRIBUTES, SYSCHECK_VALUE_TYPE] or \
-                            (SYSCHECK_ATTRIBUTES_INODE in attribute and schema == 'win32'):
+                            (SYSCHECK_ATTRIBUTES_INODE in attribute and schema == WINDOWS):
                 continue
             # Change `mtime` format to match with alerts
             elif attribute == SYSCHECK_ATTRIBUTES_MTIME:
@@ -57,7 +58,7 @@ def validate_analysis_alert_syscheck(alert, event, schema='linux'):
             elif SYSCHECK_ATTRIBUTES_HASH in attribute:
                 attribute = attribute.split('_')[-1]
             # `perm` attribute has a different format on Windows
-            elif SYSCHECK_ATTRIBUTES_PERM in attribute and schema == 'win32':
+            elif SYSCHECK_ATTRIBUTES_PERM in attribute and schema == WINDOWS:
                 if SYSCHECK_ATTRIBUTES_TYPE_REGISTRY in str(syscheck_event):
                     continue
 

--- a/src/wazuh_testing/modules/execd/__init__.py
+++ b/src/wazuh_testing/modules/execd/__init__.py
@@ -2,4 +2,12 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-PREFIX = r'.*wazuh-execd.*'
+import sys
+
+from wazuh_testing.constants.platforms import WINDOWS
+
+
+if sys.platform == WINDOWS:
+    PREFIX = r'.*execd.*'
+else:
+    PREFIX = r'.*wazuh-execd.*'

--- a/src/wazuh_testing/tools/file_monitor.py
+++ b/src/wazuh_testing/tools/file_monitor.py
@@ -52,7 +52,7 @@ class FileMonitor:
         if not os.access(self.monitored_file, os.R_OK):
             raise PermissionError(f"{self.monitored_file} is not readable.")
 
-    def start(self, callback: Callable, timeout: int = 10, accumulations: int = 1, only_new_events: bool = False) -> None:
+    def start(self, callback: Callable, timeout: int = 30, accumulations: int = 1, only_new_events: bool = False) -> None:
         """
         Start monitoring the target file using the instance provided regex and accumulate matches.
 

--- a/src/wazuh_testing/utils/configuration.py
+++ b/src/wazuh_testing/utils/configuration.py
@@ -324,9 +324,6 @@ def load_configuration_template(data_file_path, configuration_parameters=[], con
 
     configuration = file.read_yaml(data_file_path)
 
-    if sys.platform == MACOS:
-        configuration = set_correct_prefix(configuration, PREFIX) # TODO: FIX THIS.
-
     return [process_configuration(configuration[0], placeholders=replacement, metadata=meta)
             for replacement, meta in zip(configuration_parameters, configuration_metadata)]
 

--- a/src/wazuh_testing/utils/configuration.py
+++ b/src/wazuh_testing/utils/configuration.py
@@ -10,7 +10,6 @@ import xml.etree.ElementTree as ET
 
 from wazuh_testing import DATA_PATH
 from wazuh_testing.constants.paths.configurations import WAZUH_CONF_PATH, WAZUH_LOCAL_INTERNAL_OPTIONS
-from wazuh_testing.constants.platforms import MACOS
 
 from . import file
 

--- a/src/wazuh_testing/utils/configuration.py
+++ b/src/wazuh_testing/utils/configuration.py
@@ -10,6 +10,7 @@ import xml.etree.ElementTree as ET
 
 from wazuh_testing import DATA_PATH
 from wazuh_testing.constants.paths.configurations import WAZUH_CONF_PATH, WAZUH_LOCAL_INTERNAL_OPTIONS
+from wazuh_testing.constants.platforms import MACOS
 
 from . import file
 
@@ -323,8 +324,8 @@ def load_configuration_template(data_file_path, configuration_parameters=[], con
 
     configuration = file.read_yaml(data_file_path)
 
-    if sys.platform == 'darwin':
-        configuration = set_correct_prefix(configuration, PREFIX)
+    if sys.platform == MACOS:
+        configuration = set_correct_prefix(configuration, PREFIX) # TODO: FIX THIS.
 
     return [process_configuration(configuration[0], placeholders=replacement, metadata=meta)
             for replacement, meta in zip(configuration_parameters, configuration_metadata)]

--- a/src/wazuh_testing/utils/mocking.py
+++ b/src/wazuh_testing/utils/mocking.py
@@ -3,6 +3,7 @@
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 import os
 import time
+from wazuh_testing.constants.daemons import WAZUH_DB_DAEMON
 
 from wazuh_testing.constants.paths.sockets import QUEUE_DB_PATH
 from wazuh_testing.utils import client_keys, file, services
@@ -80,7 +81,7 @@ def create_mocked_agent(name='centos8-agent', ip='127.0.0.1', register_ip='127.0
                                      disconnection_time=disconnection_time)
 
     # Restart Wazuh-DB before creating new DB
-    services.control_service('restart', daemon='wazuh-db')
+    services.control_service('restart', daemon=WAZUH_DB_DAEMON)
 
     # sleep is needed since, without it, the agent database creation may fail
     time.sleep(3)

--- a/src/wazuh_testing/utils/services.py
+++ b/src/wazuh_testing/utils/services.py
@@ -12,6 +12,7 @@ from wazuh_testing.constants.daemons import CLUSTER_DAEMON, API_DAEMON, WAZUH_AG
 from wazuh_testing.constants.paths.binaries import BIN_PATH, WAZUH_CONTROL_PATH
 from wazuh_testing.constants.paths.sockets import WAZUH_SOCKETS, WAZUH_OPTIONAL_SOCKETS
 from wazuh_testing.constants.paths.variables import VAR_RUN_PATH, VERSION_FILE
+from wazuh_testing.constants.platforms import MACOS, SOLARIS, WINDOWS
 
 from . import sockets
 
@@ -29,7 +30,7 @@ def get_service() -> str:
                                        subprocess to obtain the service name.
 
     """
-    if platform.system() in ['Windows', 'win32']:
+    if platform.system() in ['Windows', WINDOWS]:
         return WAZUH_AGENT
 
     else:  # Linux, sunos5, darwin, aix...
@@ -53,7 +54,7 @@ def get_version() -> str:
                                        subprocess to obtain the version.
     """
 
-    if platform.system() in ['Windows', 'win32']:
+    if platform.system() in ['Windows', WINDOWS]:
         with open(VERSION_FILE, 'r') as f:
             version = f.read()
             return version[:version.rfind('\n')]
@@ -81,7 +82,7 @@ def control_service(action, daemon=None, debug_mode=False):
     if action not in valid_actions:
         raise ValueError(f'action {action} is not one of {valid_actions}')
 
-    if sys.platform == 'win32':
+    if sys.platform == WINDOWS:
         if action == 'restart':
             control_service('stop')
             control_service('start')
@@ -104,7 +105,7 @@ def control_service(action, daemon=None, debug_mode=False):
                         break
     else:  # Default Unix
         if daemon is None:
-            if sys.platform == 'darwin' or sys.platform == 'sunos5':
+            if sys.platform == MACOS or sys.platform == SOLARIS:
                 result = subprocess.run(
                     [WAZUH_CONTROL_PATH, action]).returncode
             else:
@@ -174,7 +175,7 @@ def check_daemon_status(target_daemon=None, running_condition=True, timeout=10, 
     elapsed_time = 0
 
     while elapsed_time < timeout and not condition_met:
-        if sys.platform == 'win32':
+        if sys.platform == WINDOWS:
             condition_met = check_if_process_is_running(WAZUH_AGENT_WIN) == running_condition
         else:
             control_status_output = subprocess.run([WAZUH_CONTROL_PATH, 'status'],


### PR DESCRIPTION
|Related Issue|
|---|
| https://github.com/wazuh/qa-integration-framework/issues/15|

## Description

This PR applies the platform constants on all the _platform conditionals_, it also adds a default timeout when the tests are being executed on Windows and gives 10 more seconds to the `FileMonitor` default monitor.