### PR TITLE
Remove deprecated `ssl` function call

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ You can just import it from the test suite as any other python library
 ```python
 from wazuh_testing.constants.paths.logs import WAZUH_LOG_PATH
 from wazuh_testing.modules.analysisd import patterns
-from wazuh_testing.tools import file_monitor
+from wazuh_testing.tools.monitors.file_monitor import FileMonitor
 from wazuh_testing.utils import callbacks
 
 
-monitor = file_monitor.FileMonitor(WAZUH_LOG_PATH)
+monitor = FileMonitor(WAZUH_LOG_PATH)
 monitor.start(callback=callbacks.generate_callback(patterns.ANALYSISD_STARTED))
 
 ```

--- a/src/wazuh_testing/tools/mitm.py
+++ b/src/wazuh_testing/tools/mitm.py
@@ -94,27 +94,18 @@ class SSLStreamServerPort(socketserver.ThreadingTCPServer):
             raise Exception('SSL configuration needs to be set in SSLStreamServer')
 
         try:
+            context = ssl.SSLContext(self.ssl_version)
             if self.options:
-                context = ssl.SSLContext(self.ssl_version)
                 context.options = self.options
-                if self.certfile:
-                    context.load_cert_chain(self.certfile, self.keyfile)
-                if self.ca_cert is None:
-                    context.verify_mode = ssl.CERT_NONE
-                else:
-                    context.verify_mode = self.cert_reqs
-                    context.load_verify_locations(cafile=self.ca_cert)
-                context.set_ciphers(self.ciphers)
-                connstream = context.wrap_socket(newsocket, server_side=True)
+            if self.certfile:
+                context.load_cert_chain(self.certfile, self.keyfile)
+            if self.ca_cert is None:
+                context.verify_mode = ssl.CERT_NONE
             else:
-                connstream = ssl.wrap_socket(newsocket,
-                                             server_side=True,
-                                             certfile=self.certfile,
-                                             keyfile=self.keyfile,
-                                             ssl_version=self.ssl_version,
-                                             ciphers=self.ciphers,
-                                             cert_reqs=self.cert_reqs,
-                                             ca_certs=self.ca_cert)
+                context.verify_mode = self.cert_reqs
+                context.load_verify_locations(cafile=self.ca_cert)
+            context.set_ciphers(self.ciphers)
+            connstream = context.wrap_socket(newsocket, server_side=True)
         except OSError as err:
             print(err)
             raise


### PR DESCRIPTION
| Related issue |
|----------------|
| #17                |

## Descrption

This PR removes the deprecated function call `ssl.wrap_socket()` avoiding the raise of warning logs when it is called. Now only the non-deprecated functions from the `ssl` library are used.

closes #17 

### Error reproduction
In the previous code when `execd` ITs are executed, a Warning is raised because the `AuthdSimulator` calls the deprecated function.
> Job of the execution with the error: [`10005021493`]( https://github.com/wazuh/wazuh/actions/runs/5489868617/jobs/10005021493)
```vim
============================= test session starts =============================
platform win32 -- Python 3.10.11, pytest-7.1.2, pluggy-1.2.0
rootdir: C:\wazuh\tests\integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0
collected 6 items / 4 deselected / 2 selected

test_execd\test_run_active_response\test_restart_wazuh.py ..             [100%]

============================== warnings summary ===============================
test_execd/test_run_active_response/test_restart_wazuh.py::test_execd_restart[Command execution succeed0]
  C:\hostedtoolcache\windows\Python\3.10.11\x64\lib\site-packages\wazuh_testing\tools\mitm.py:110: DeprecationWarning: ssl.wrap_socket() is deprecated, use SSLContext.wrap_socket()
    connstream = ssl.wrap_socket(newsocket,

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========== 2 passed, 4 deselected, 1 warning in 130.04s (0:02:10) ============
```

### Current behavior
The warning is not raised anymore.
> Job with the fixed code: [`10068557966`](https://github.com/wazuh/wazuh/actions/runs/5520988265/jobs/10068557966?pr=17876)
```vim
============================= test session starts =============================
platform win32 -- Python 3.10.11, pytest-7.1.2, pluggy-1.2.0
rootdir: C:\wazuh\tests\integration, configfile: pytest.ini
plugins: html-3.1.1, metadata-3.0.0
collected 6 items / 4 deselected / 2 selected

test_execd\test_run_active_response\test_restart_wazuh.py ..             [100%]

================= 2 passed, 4 deselected in 132.92s (0:02:12) =================
```