### PR TITLE
17700 refactor and migrate rootcheck integration tests

### DIFF
--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -1687,9 +1687,12 @@ class InjectorThread(threading.Thread):
                         break
 
                 event = self.agent.create_event(event_msg)
-                self.sender.send_event(event)
-                self.totalMessages += 1
-                sent_messages += 1
+                try:
+                    self.sender.send_event(event)
+                    self.totalMessages += 1
+                    sent_messages += 1
+                except Exception as e:
+                    logging.debug(f"Send a module message - {e}")
                 if self.totalMessages % eps == 0:
                     sleep(1.0 - ((time() - start_time) % 1.0))
 


### PR DESCRIPTION
|Related Epic       |           Related issue|
|-----------------------| ---------------------------|
|  wazuh/wazuh#17427    |   wazuh/wazuh#17700     |

# Description
This PR includes all the necessary changes to move the rootcheck integration tests from wazuh-qa to this repository. This test requires (https://github.com/wazuh/qa-integration-framework/pull/22).

And, finally, this PR just avoid this error:

```
self.socket.send(length + event)
  OSError: [Errno 9] Bad file descriptor
```