### PR TITLE
Add retries to login and change default values

### DIFF
--- a/src/wazuh_testing/modules/api/utils.py
+++ b/src/wazuh_testing/modules/api/utils.py
@@ -92,7 +92,8 @@ def login(user: str = WAZUH_API_USER, password: str = WAZUH_API_PASSWORD,
         response (requests.Response): Response object.
 
     Raises:
-        RuntimeError(msg, requests.Response): When could not login after `login_attempts` every `backoff_factor`
+        RuntimeError(msg, requests.Response): When could not login after `login_attempts` every timeout determined by 
+        the `backoff_factor`.
     """
     url = f"{get_base_url(protocol=protocol, host=host, port=port)}{LOGIN_ROUTE}"
 


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/18651 |

## Description

Changed the `login` function `login_attempts` parameter to make more than 1 attempt by default. Replaced the `sleep_time` parameter with `backoff_factor` to use a retry strategy for the requests in case of receiving connection refused errors.

## Tests

- https://github.com/wazuh/wazuh/actions/runs/6261596516
- https://github.com/wazuh/wazuh/actions/runs/6261597845
- https://github.com/wazuh/wazuh/actions/runs/6261598968