### PR TITLE
Remove group commands

### DIFF
--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
@@ -308,16 +308,10 @@
                                           "get-all-agents": {
                                             "type": "integer"
                                           },
-                                          "get-groups-integrity": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent": {
                                             "type": "integer"
                                           },
                                           "reset-agents-connection": {
-                                            "type": "integer"
-                                          },
-                                          "select-agent-group": {
                                             "type": "integer"
                                           },
                                           "select-agent-name": {
@@ -355,10 +349,8 @@
                                           "get-agent-info",
                                           "get-agents-by-connection-status",
                                           "get-all-agents",
-                                          "get-groups-integrity",
                                           "insert-agent",
                                           "reset-agents-connection",
-                                          "select-agent-group",
                                           "select-agent-name",
                                           "set-agent-groups",
                                           "sync-agent-groups-get",
@@ -391,9 +383,6 @@
                                           "delete-group": {
                                             "type": "integer"
                                           },
-                                          "find-group": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent-group": {
                                             "type": "integer"
                                           },
@@ -403,7 +392,6 @@
                                         },
                                         "required": [
                                           "delete-group",
-                                          "find-group",
                                           "insert-agent-group",
                                           "select-groups"
                                         ]
@@ -851,16 +839,10 @@
                                           "get-all-agents": {
                                             "type": "integer"
                                           },
-                                          "get-groups-integrity": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent": {
                                             "type": "integer"
                                           },
                                           "reset-agents-connection": {
-                                            "type": "integer"
-                                          },
-                                          "select-agent-group": {
                                             "type": "integer"
                                           },
                                           "select-agent-name": {
@@ -898,10 +880,8 @@
                                           "get-agent-info",
                                           "get-agents-by-connection-status",
                                           "get-all-agents",
-                                          "get-groups-integrity",
                                           "insert-agent",
                                           "reset-agents-connection",
-                                          "select-agent-group",
                                           "select-agent-name",
                                           "set-agent-groups",
                                           "sync-agent-groups-get",
@@ -934,9 +914,6 @@
                                           "delete-group": {
                                             "type": "integer"
                                           },
-                                          "find-group": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent-group": {
                                             "type": "integer"
                                           },
@@ -946,7 +923,6 @@
                                         },
                                         "required": [
                                           "delete-group",
-                                          "find-group",
                                           "insert-agent-group",
                                           "select-groups"
                                         ]


### PR DESCRIPTION
|Related issue|
|-------------|
|      Closes https://github.com/wazuh/wazuh-qa/issues/4217       |

## Description

Removed the deprecated commands `get-groups-integrity`, `select-agent-group` and `find-group` from the tests.

<details><summary>Tests execution</summary>

Build: https://github.com/wazuh/wazuh/actions/runs/6419146728/job/17428378145?pr=19420

```console
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.3.0
rootdir: /home/runner/work/wazuh/wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.0.0, html-3.1.1
collected 61 items / 3 deselected / 58 selected

test_api/test_config/test_DOS_blocking_system/test_DOS_blocking_system.py . [  1%]
                                                                         [  1%]
test_api/test_config/test_bruteforce_blocking_system/test_bruteforce_blocking_system.py . [  3%]
                                                                         [  3%]
test_api/test_config/test_cache/test_cache.py ..                         [  6%]
test_api/test_config/test_cors/test_cors.py x.                           [ 10%]
test_api/test_config/test_drop_privileges/test_drop_privileges.py ..     [ 13%]
test_api/test_config/test_experimental_features/test_experimental_features.py . [ 15%]
.                                                                        [ 17%]
test_api/test_config/test_host_port/test_host_port.py ....               [ 24%]
test_api/test_config/test_https/test_https.py ..                         [ 27%]
test_api/test_config/test_jwt_token_exp_timeout/test_jwt_token_exp_timeout.py . [ 29%]
.                                                                        [ 31%]
test_api/test_config/test_logs/test_logs_format.py ........              [ 44%]
test_api/test_config/test_rbac/test_rbac_mode.py ..                      [ 48%]
test_api/test_config/test_request_timeout/test_request_timeout.py .      [ 50%]
test_api/test_middlewares/test_response_postprocessing.py ....           [ 56%]
test_api/test_middlewares/test_set_secure_headers.py .                   [ 58%]
test_api/test_rbac/test_add_old_resource.py ....                         [ 65%]
test_api/test_rbac/test_manage_admin_resource.py .......                 [ 77%]
test_api/test_rbac/test_policy_position.py .                             [ 79%]
test_api/test_rbac/test_remove_resource.py ....                          [ 86%]
test_api/test_rbac/test_remove_resources_relation.py ...                 [ 91%]
test_api/test_statistics/test_statistics_format.py .....                 [100%]

=========== 57 passed, 3 deselected, 1 xfailed in 834.27s (0:13:54) ============
```

</details>