### PR TITLE
Remove group commands

### DIFF
--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
@@ -308,16 +308,10 @@
                                           "get-all-agents": {
                                             "type": "integer"
                                           },
-                                          "get-groups-integrity": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent": {
                                             "type": "integer"
                                           },
                                           "reset-agents-connection": {
-                                            "type": "integer"
-                                          },
-                                          "select-agent-group": {
                                             "type": "integer"
                                           },
                                           "select-agent-name": {
@@ -355,10 +349,8 @@
                                           "get-agent-info",
                                           "get-agents-by-connection-status",
                                           "get-all-agents",
-                                          "get-groups-integrity",
                                           "insert-agent",
                                           "reset-agents-connection",
-                                          "select-agent-group",
                                           "select-agent-name",
                                           "set-agent-groups",
                                           "sync-agent-groups-get",
@@ -391,9 +383,6 @@
                                           "delete-group": {
                                             "type": "integer"
                                           },
-                                          "find-group": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent-group": {
                                             "type": "integer"
                                           },
@@ -403,7 +392,6 @@
                                         },
                                         "required": [
                                           "delete-group",
-                                          "find-group",
                                           "insert-agent-group",
                                           "select-groups"
                                         ]
@@ -851,16 +839,10 @@
                                           "get-all-agents": {
                                             "type": "integer"
                                           },
-                                          "get-groups-integrity": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent": {
                                             "type": "integer"
                                           },
                                           "reset-agents-connection": {
-                                            "type": "integer"
-                                          },
-                                          "select-agent-group": {
                                             "type": "integer"
                                           },
                                           "select-agent-name": {
@@ -898,10 +880,8 @@
                                           "get-agent-info",
                                           "get-agents-by-connection-status",
                                           "get-all-agents",
-                                          "get-groups-integrity",
                                           "insert-agent",
                                           "reset-agents-connection",
-                                          "select-agent-group",
                                           "select-agent-name",
                                           "set-agent-groups",
                                           "sync-agent-groups-get",
@@ -934,9 +914,6 @@
                                           "delete-group": {
                                             "type": "integer"
                                           },
-                                          "find-group": {
-                                            "type": "integer"
-                                          },
                                           "insert-agent-group": {
                                             "type": "integer"
                                           },
@@ -946,7 +923,6 @@
                                         },
                                         "required": [
                                           "delete-group",
-                                          "find-group",
                                           "insert-agent-group",
                                           "select-groups"
                                         ]

--- a/src/wazuh_testing/utils/db_queries/global_db.py
+++ b/src/wazuh_testing/utils/db_queries/global_db.py
@@ -9,7 +9,7 @@ def create_or_update_agent(agent_id='001', name='centos8-agent', ip='127.0.0.1',
                            os_codename='centos-8', os_build='4.18.0-147.8.1.el8_1.x86_64',
                            os_platform='#1 SMP Thu Apr 9 13:49:54 UTC 2020', os_uname='x86_64', os_arch='x86_64',
                            version='Wazuh v4.3.0', config_sum='', merged_sum='', manager_host='centos-8',
-                           node_name='node01', date_add='1612942494', last_keepalive='253402300799', group='',
+                           node_name='node01', date_add='1612942494', last_keepalive='253402300799',
                            sync_status='synced', connection_status='active', disconnection_time='0'):
     """Create an agent or update its info if it already exists (checking agent_id).
 
@@ -35,18 +35,17 @@ def create_or_update_agent(agent_id='001', name='centos8-agent', ip='127.0.0.1',
         node_name (str): Name of the node.
         date_add (str): Date of the added/updated agent.
         last_keepalive (str): Last keep alive timestamp reported.
-        group (str): Group of the agent.
         sync_status (str): Status of the syncronization.
         connection_status (str): Status of the connection.
         disconnection_time (str): Last disconnection time.
     """
     query = 'global sql INSERT OR REPLACE INTO AGENT  (id, name, ip, register_ip, internal_key, os_name, os_version, ' \
             'os_major, os_minor, os_codename, os_build, os_platform, os_uname, os_arch, version, config_sum, ' \
-            'merged_sum, manager_host, node_name, date_add, last_keepalive, "group", sync_status, connection_status, ' \
+            'merged_sum, manager_host, node_name, date_add, last_keepalive, sync_status, connection_status, ' \
             f"disconnection_time) VALUES  ('{agent_id}', '{name}', '{ip}', '{register_ip}', '{internal_key}', " \
             f"'{os_name}', '{os_version}', '{os_major}', '{os_minor}', '{os_codename}', '{os_build}', " \
             f"'{os_platform}', '{os_uname}', '{os_arch}', '{version}', '{config_sum}', '{merged_sum}', " \
-            f"'{manager_host}', '{node_name}', '{date_add}', '{last_keepalive}', '{group}', '{sync_status}', " \
+            f"'{manager_host}', '{node_name}', '{date_add}', '{last_keepalive}', '{sync_status}', " \
             f"'{connection_status}', '{disconnection_time}')"
 
     database.query_wdb(query)

--- a/src/wazuh_testing/utils/mocking.py
+++ b/src/wazuh_testing/utils/mocking.py
@@ -142,7 +142,7 @@ def create_mocked_agent(id=None, name='centos8-agent', ip='127.0.0.1', register_
                         os_build='4.18.0-147.8.1.el8_1.x86_64', os_platform='#1 SMP Thu Apr 9 13:49:54 UTC 2020',
                         os_uname='x64', os_arch='x64', version='Wazuh v4.3.0', config_sum='', merged_sum='',
                         manager_host='centos-8', node_name='node01', date_add='1612942494', hostname='centos-8',
-                        last_keepalive='253402300799', group='', sync_status='synced', connection_status='active',
+                        last_keepalive='253402300799', sync_status='synced', connection_status='active',
                         client_key_secret=None, os_release='', os_patch='', release='', sysname='Linux',
                         checksum='checksum', os_display_version='', triaged='0', reference='', disconnection_time='0',
                         architecture='x64'):
@@ -172,7 +172,6 @@ def create_mocked_agent(id=None, name='centos8-agent', ip='127.0.0.1', register_
         date_add (str): Date of the added/updated agent.
         hostname (str): Hostname.
         last_keepalive (str): Last keep alive timestamp reported.
-        group (str): Group of the agent.
         sync_status (str): Status of the syncronization.
         connection_status (str): Status of the connection.
         client_key_secret (str): Client secret key.
@@ -207,7 +206,7 @@ def create_mocked_agent(id=None, name='centos8-agent', ip='127.0.0.1', register_
                                      os_major=os_major, os_minor=os_minor, os_codename=os_codename, os_build=os_build,
                                      os_platform=os_platform, os_uname=os_uname, os_arch=os_arch, version=version,
                                      config_sum=config_sum, merged_sum=merged_sum, manager_host=manager_host,
-                                     node_name=node_name, date_add=date_add, last_keepalive=last_keepalive, group=group,
+                                     node_name=node_name, date_add=date_add, last_keepalive=last_keepalive,
                                      sync_status=sync_status, connection_status=connection_status,
                                      disconnection_time=disconnection_time)
 


### PR DESCRIPTION
## Description

Removed the deprecated commands `get-groups-integrity`, `select-agent-group` and `find-group` from the tests.

Remove the `group` column from agent mocking functions.