### PR TITLE
Fix RemotedSimulator udp connections

### DIFF
--- a/src/wazuh_testing/tools/mitm.py
+++ b/src/wazuh_testing/tools/mitm.py
@@ -228,8 +228,9 @@ class DatagramHandler(socketserver.BaseRequestHandler):
             self.default_wazuh_handler()
         else:
             data = self.request[0]
-            self.server.mitm.handler_func(data)
+            response = self.server.mitm.handler_func(data)
             self.server.mitm.put_queue(data)
+            self.request[1].sendto(response, self.client_address)
 
 
 class ManInTheMiddle:


### PR DESCRIPTION
|Related issue|
|---|
| https://github.com/wazuh/qa-integration-framework/issues/41 |
| https://github.com/wazuh/wazuh/issues/17696 |

## Description
During the development of the Agentd IT test migration, it was found, RemotedSimulator was not mocking properly the UDP connection. It was due to the MITM object not sending a response to the agent. This PR fixes it and lets the agent establish the connection as expected.

Now the following logs appear using UDP:
```
2024/01/10 22:29:31 wazuh-agentd[29667] start_agent.c:93 at connect_server(): INFO: Trying to connect to server ([127.0.0.1]:1514/udp).
2024/01/10 22:29:31 wazuh-agentd[29667] start_agent.c:365 at agent_handshake_to_server(): INFO: (4102): Connected to the server ([127.0.0.1]:1514/udp).
2024/01/10 22:29:31 wazuh-agentd[29667] pthreads_op.c:45 at CreateThreadJoinable(): DEBUG: Thread stack size set to: 8192 KiB
2024/01/10 22:29:31 wazuh-agentd[29667] notify.c:129 at run_notify(): DEBUG: Sending agent notification.
2024/01/10 22:29:31 wazuh-agentd[29667] notify.c:198 at run_notify(): DEBUG: Sending keep alive: #!-Linux |agent3-ubu22 |5.15.0-91-generic |#101-Ubuntu SMP Tue Nov 14 13:30:08 UTC 2023 |x86_64 [Ubuntu|ubuntu: 22.04 (Jammy Jellyfish)] - Wazuh v4.9.0
x merged.mg
#"_agent_ip":127.0.0.1

2024/01/10 22:29:31 wazuh-agentd[29667] receiver.c:96 at receive_msg(): DEBUG: Received message: '#!-agent ack '
```