### PR TITLE
Update wazuh-db statistics template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Updated name of the `vulnerability-detection` configuration block in the `all_disabled_ossec.conf` file. ([#51](https://github.com/wazuh/qa-integration-framework/pull/51))
+- Updated the `wazuh-db_template.json` to remove vulnerability detector fields. ([#89](https://github.com/wazuh/qa-integration-framework/pull/89))
 
 ## [4.7.2]
 

--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
@@ -226,17 +226,6 @@
                                           "syscollector_processes",
                                           "deprecated"
                                         ]
-                                      },
-                                      "vulnerability": {
-                                        "type": "object",
-                                        "properties": {
-                                          "vuln_cves": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "vuln_cves"
-                                        ]
                                       }
                                     },
                                     "required": [
@@ -245,8 +234,7 @@
                                       "sca",
                                       "sync",
                                       "syscheck",
-                                      "syscollector",
-                                      "vulnerability"
+                                      "syscollector"
                                     ]
                                   }
                                 },
@@ -769,17 +757,6 @@
                                           "syscollector_processes",
                                           "deprecated"
                                         ]
-                                      },
-                                      "vulnerability": {
-                                        "type": "object",
-                                        "properties": {
-                                          "vuln_cves": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "vuln_cves"
-                                        ]
                                       }
                                     },
                                     "required": [
@@ -788,8 +765,7 @@
                                       "sca",
                                       "sync",
                                       "syscheck",
-                                      "syscollector",
-                                      "vulnerability"
+                                      "syscollector"
                                     ]
                                   }
                                 },


### PR DESCRIPTION
| Related issue |
|--|
|https://github.com/wazuh/wazuh/issues/21303|

# Description

Update the statistics template in the API test after the core team removed all references of the legacy vulnerability detector module.