### PR TITLE
Fixes response of agent_simulator for active-response config request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed bug in the service control function for Windows agents. ([#121](https://github.com/wazuh/qa-integration-framework/pull/121))
 - Fixed bug in the RemotedSimulator udp connections mocker. ([#86](https://github.com/wazuh/qa-integration-framework/pull/86))
-- - Fixed agent_simulator response for active-response configuration commands. ([#4895](https://github.com/wazuh/wazuh-qa/pull/4895))
+- Fixed agent_simulator response for active-response configuration commands. ([#139](https://github.com/wazuh/qa-integration-framework/pull/139))
 
 ## [4.8.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed bug in the service control function for Windows agents. ([#121](https://github.com/wazuh/qa-integration-framework/pull/121))
 - Fixed bug in the RemotedSimulator udp connections mocker. ([#86](https://github.com/wazuh/qa-integration-framework/pull/86))
+- - Fixed agent_simulator response for active-response configuration commands. ([#4895](https://github.com/wazuh/wazuh-qa/pull/4895))
 
 ## [4.8.2]
 

--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -578,7 +578,7 @@ class Agent:
                                                         f'{{"error":0, "message":"ok", "data":[]}} '))
         elif command == 'getconfig':
             if "active-response" in message_list:
-                response_json = '{{"active-response":{"disabled":"no"}}'
+                response_json = '{"active-response":{"disabled":"no"}}'
             else:
                 response_json = '{"client":{"config-profile":"centos8","notify_time":10,"time-reconnect":60}}'
             sender.send_event(self.create_event(f'#!-req {req_code} ok {response_json}'))

--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -577,7 +577,10 @@ class Agent:
                     sender.send_event(self.create_event(f'#!-req {req_code} '
                                                         f'{{"error":0, "message":"ok", "data":[]}} '))
         elif command == 'getconfig':
-            response_json = '{"client":{"config-profile":"centos8","notify_time":10,"time-reconnect":60}}'
+            if "active-response" in message_list:
+                response_json = '{{"active-response":{"disabled":"no"}}'
+            else:
+                response_json = '{"client":{"config-profile":"centos8","notify_time":10,"time-reconnect":60}}'
             sender.send_event(self.create_event(f'#!-req {req_code} ok {response_json}'))
         elif command == 'getstate':
             response_json = '{"error":0,"data":{"global":{"start":"2021-02-26, 06:41:26","end":"2021-02-26 08:49:19"}}}'


### PR DESCRIPTION
| Issue |
|---------|
| https://github.com/wazuh/wazuh-qa/issues/1266|

# Description
Fixes the response of the `agent simulator` for the active-response configuration messages.



