### PR TITLE
Allow setting different regions to generated AWS resources

### DIFF
--- a/src/wazuh_testing/modules/aws/data_generator.py
+++ b/src/wazuh_testing/modules/aws/data_generator.py
@@ -23,18 +23,20 @@ def get_random_interface_id():
 
 
 class DataGenerator:
-    BASE_PATH = ''
-    BASE_FILE_NAME = ''
+    """Base class to generate AWS Bucket related data."""
 
-    compress = False
-
-    def __init__(self, date: datetime) -> None:
+    def __init__(self, date: datetime, region: str) -> None:
         """Initialize a DataGenerator instance.
 
         Args:
             date (datetime): Time to be used to generate the filename and dates inside the data sample.
+            region (str): The region name for the file path and file key.
         """
-        self.date = date 
+        self.date = date
+        self.region = region if region else US_EAST_1_REGION
+        self.base_path = ''
+        self.base_file_name = ''
+        self.compress = False
 
     def get_filename(self, *args, **kwargs) -> str:
         """Return the filename according to the integration format.
@@ -54,8 +56,10 @@ class DataGenerator:
 
 
 class CloudTrailDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, CLOUDTRAIL, US_EAST_1_REGION)
-    BASE_FILE_NAME = f"{RANDOM_ACCOUNT_ID}_{CLOUDTRAIL}_{US_EAST_1_REGION}_"
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, CLOUDTRAIL, self.region)
+        self.base_file_name = f"{RANDOM_ACCOUNT_ID}_{CLOUDTRAIL}_{self.region}_"
 
     def get_filename(self) -> str:
         """Return the filename in the cloudtrail format.
@@ -66,8 +70,8 @@ class CloudTrailDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}{JSON_EXT}"
 
         return join(path, name)
 
@@ -88,7 +92,7 @@ class CloudTrailDataGenerator(DataGenerator):
                     'eventTime': self.date.strftime(EVENT_TIME_FORMAT),
                     'eventSource': 'sts.amazonaws.com',
                     'eventName': 'AssumeRole',
-                    'awsRegion': US_EAST_1_REGION,
+                    'awsRegion': self.region,
                     'sourceIPAddress': 'ec2.amazonaws.com',
                     'userAgent': 'ec2.amazonaws.com',
                     'requestParameters': {
@@ -123,8 +127,10 @@ class CloudTrailDataGenerator(DataGenerator):
 
 
 class VPCDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, VPC_FLOW_LOGS, US_EAST_1_REGION)
-    BASE_FILE_NAME = f"{RANDOM_ACCOUNT_ID}_{VPC_FLOW_LOGS}_{US_EAST_1_REGION}_"
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, VPC_FLOW_LOGS, self.region)
+        self.base_file_name = f"{RANDOM_ACCOUNT_ID}_{VPC_FLOW_LOGS}_{self.region}_"
 
     def get_filename(self, **kwargs) -> str:
         """Return the filename in the VPC format.
@@ -135,9 +141,9 @@ class VPCDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
         name = (
-            f"{self.BASE_FILE_NAME}{kwargs['flow_log_id']}_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}"
+            f"{self.base_file_name}{kwargs['flow_log_id']}_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}"
             f"{LOG_EXT}"
         )
 
@@ -170,8 +176,10 @@ class VPCDataGenerator(DataGenerator):
 
 
 class ConfigDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, CONFIG, US_EAST_1_REGION)
-    BASE_FILE_NAME = f"{RANDOM_ACCOUNT_ID}_{CONFIG}_{US_EAST_1_REGION}_ConfigHistory_AWS_"
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, CONFIG, self.region)
+        self.base_file_name = f"{RANDOM_ACCOUNT_ID}_{CONFIG}_{self.region}_ConfigHistory_AWS_"
 
     def get_filename(self) -> str:
         """Return the filename in the Config format.
@@ -182,8 +190,8 @@ class ConfigDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_NO_PADED_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_NO_PADED_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}{JSON_EXT}"
 
         return join(path, name)
 
@@ -237,8 +245,11 @@ class ConfigDataGenerator(DataGenerator):
 
 
 class ALBDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, ELASTIC_LOAD_BALANCING, US_EAST_1_REGION)
-    BASE_FILE_NAME = f"{RANDOM_ACCOUNT_ID}_{ELASTIC_LOAD_BALANCING}_{US_EAST_1_REGION}_"
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, ELASTIC_LOAD_BALANCING, self.region)
+        self.base_file_name = f"{RANDOM_ACCOUNT_ID}_{ELASTIC_LOAD_BALANCING}_{self.region}_"
+
 
     def get_filename(self) -> str:
         """Return the filename in the ALB format.
@@ -249,9 +260,9 @@ class ALBDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
         name = (
-            f"{self.BASE_FILE_NAME}_app.ALB-qatests_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}_"
+            f"{self.base_file_name}_app.ALB-qatests_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}_"
             f"{get_random_ip()}_pczeay_{LOG_EXT}"
         )
 
@@ -307,8 +318,10 @@ class ALBDataGenerator(DataGenerator):
 
 
 class CLBDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, ELASTIC_LOAD_BALANCING, US_EAST_1_REGION)
-    BASE_FILE_NAME = f"{RANDOM_ACCOUNT_ID}_{ELASTIC_LOAD_BALANCING}_{US_EAST_1_REGION}_"
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, ELASTIC_LOAD_BALANCING, self.region)
+        self.base_file_name = f"{RANDOM_ACCOUNT_ID}_{ELASTIC_LOAD_BALANCING}_{self.region}_"
 
     def get_filename(self) -> str:
         """Return the filename in the CLB format.
@@ -319,9 +332,9 @@ class CLBDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
         name = (
-            f"{self.BASE_FILE_NAME}qatests-APIClassi_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}_"
+            f"{self.base_file_name}qatests-APIClassi_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}_"
             f"{get_random_ip()}{LOG_EXT}"
         )
 
@@ -361,8 +374,10 @@ class CLBDataGenerator(DataGenerator):
 
 
 class NLBDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, ELASTIC_LOAD_BALANCING, US_EAST_1_REGION)
-    BASE_FILE_NAME = f"{RANDOM_ACCOUNT_ID}_{ELASTIC_LOAD_BALANCING}_{US_EAST_1_REGION}_"
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, ELASTIC_LOAD_BALANCING, self.region)
+        self.base_file_name = f"{RANDOM_ACCOUNT_ID}_{ELASTIC_LOAD_BALANCING}_{self.region}_"
 
     def get_filename(self) -> str:
         """Return the filename in the NLB format.
@@ -373,9 +388,9 @@ class NLBDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
         name = (
-            f"{self.BASE_FILE_NAME}net.qatests_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}_"
+            f"{self.base_file_name}net.qatests_{self.date.strftime(FILENAME_DATE_FORMAT)}_{abs(hash(self.date))}_"
             f"{get_random_ip()}{LOG_EXT}"
         )
 
@@ -421,8 +436,10 @@ class NLBDataGenerator(DataGenerator):
 
 
 class KMSDataGenerator(DataGenerator):
-    BASE_PATH = ''
-    BASE_FILE_NAME = 'firehose_kms-1-'
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = ''
+        self.base_file_name = 'firehose_kms-1-'
 
     def get_filename(self) -> str:
         """Return the filename in the KMS format.
@@ -433,8 +450,8 @@ class KMSDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}_{str(uuid4())}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}_{str(uuid4())}{JSON_EXT}"
 
         return join(path, name)
 
@@ -504,8 +521,10 @@ class KMSDataGenerator(DataGenerator):
 
 
 class MacieDataGenerator(DataGenerator):
-    BASE_PATH = ''
-    BASE_FILE_NAME = 'firehose_macie-1-'
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = ''
+        self.base_file_name = 'firehose_macie-1-'
 
     def get_filename(self) -> str:
         """Return the filename in the Macie format.
@@ -516,8 +535,8 @@ class MacieDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}_{str(uuid4())}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}_{str(uuid4())}{JSON_EXT}"
 
         return join(path, name)
 
@@ -610,9 +629,11 @@ class MacieDataGenerator(DataGenerator):
 
 
 class TrustedAdvisorDataGenerator(DataGenerator):
-    BASE_PATH = ''
-    BASE_FILE_NAME = 'firehose_trustedadvisor-1-'
-
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = ''
+        self.base_file_name = 'firehose_trustedadvisor-1-'
+        
     def get_filename(self) -> str:
         """Return the filename in the Trusted Advisor format.
 
@@ -622,8 +643,8 @@ class TrustedAdvisorDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}{JSON_EXT}"
 
         return join(path, name)
 
@@ -662,8 +683,10 @@ class TrustedAdvisorDataGenerator(DataGenerator):
 
 
 class GuardDutyDataGenerator(DataGenerator):
-    BASE_PATH = ''
-    BASE_FILE_NAME = 'firehose_guardduty-1-'
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = ''
+        self.base_file_name = 'firehose_guardduty-1-'
 
     def get_filename(self) -> str:
         """Return the filename in the Guard Duty format.
@@ -674,8 +697,8 @@ class GuardDutyDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}{JSON_EXT}"
 
         return join(path, name)
 
@@ -822,10 +845,11 @@ class GuardDutyDataGenerator(DataGenerator):
 
 
 class NativeGuardDutyDataGenerator(DataGenerator):
-    BASE_PATH = join(AWS_LOGS, RANDOM_ACCOUNT_ID, GUARDDUTY, US_EAST_1_REGION)
-    BASE_FILE_NAME = ''
-
-    compress = True
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = join(AWS_LOGS, RANDOM_ACCOUNT_ID, GUARDDUTY, self.region)
+        self.base_file_name = ''
+        self.compress = True
 
     def get_filename(self) -> str:
         """Return the filename in the Native Guard Duty format.
@@ -836,7 +860,7 @@ class NativeGuardDutyDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
         name = f"{str(uuid4())}{JSON_GZ_EXT}"
 
         return join(path, name)
@@ -964,8 +988,10 @@ class NativeGuardDutyDataGenerator(DataGenerator):
 
 
 class WAFDataGenerator(DataGenerator):
-    BASE_PATH = ''
-    BASE_FILE_NAME = 'aws-waf-logs-delivery-stream-1-'
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = ''
+        self.base_file_name = 'aws-waf-logs-delivery-stream-1-'
 
     def get_filename(self) -> str:
         """Return the filename in the KMS format.
@@ -976,8 +1002,8 @@ class WAFDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime(PATH_DATE_FORMAT))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime(FILENAME_DATE_FORMAT)}{JSON_EXT}"
+        path = join(self.base_path, self.date.strftime(PATH_DATE_FORMAT))
+        name = f"{self.base_file_name}{self.date.strftime(FILENAME_DATE_FORMAT)}{JSON_EXT}"
 
         return join(path, name)
 
@@ -1052,9 +1078,6 @@ class WAFDataGenerator(DataGenerator):
 
 
 class ServerAccessDataGenerator(DataGenerator):
-    BASE_PATH = ''
-    BASE_FILE_NAME = ''
-
     def get_filename(self) -> str:
         """Return the filename in the server access format.
 
@@ -1066,7 +1089,7 @@ class ServerAccessDataGenerator(DataGenerator):
         """
         date_format = '%Y-%m-%d-%H-%M-%S'
         name = f"{self.date.strftime(date_format)}-{get_random_string(16).upper()}"
-        return join(self.BASE_PATH, name)
+        return join(self.base_path, name)
 
     def get_data_sample(self):
         """Return a sample of data according to the server access format.
@@ -1102,8 +1125,10 @@ class ServerAccessDataGenerator(DataGenerator):
 
 
 class UmbrellaDataGenerator(DataGenerator):
-    BASE_PATH = 'dnslogs'
-    BASE_FILE_NAME = ''
+    def __init__(self, date: datetime, region: str) -> None:
+        super().__init__(date, region)
+        self.base_path = 'dnslogs'
+        self.base_file_name = ''
 
     def get_filename(self) -> str:
         """Return the filename in the Umbrella format.
@@ -1114,8 +1139,8 @@ class UmbrellaDataGenerator(DataGenerator):
         Returns:
             str: Synthetic filename.
         """
-        path = join(self.BASE_PATH, self.date.strftime('%Y-%m-%d'))
-        name = f"{self.BASE_FILE_NAME}{self.date.strftime('%Y-%m-%d')}-00-00-ioxa{CSV_EXT}"
+        path = join(self.base_path, self.date.strftime('%Y-%m-%d'))
+        name = f"{self.base_file_name}{self.date.strftime('%Y-%m-%d')}-00-00-ioxa{CSV_EXT}"
 
         return join(path, name)
 
@@ -1167,13 +1192,14 @@ buckets_data_mapping = {
 }
 
 
-def get_data_generator(bucket_type, bucket_name, creation_date) -> DataGenerator:
+def get_data_generator(bucket_type, bucket_name, creation_date, region) -> DataGenerator:
     """Given the bucket type return the correspondant data generator instance.
 
     Args:
         bucket_type (str): Bucket type to match the data generator.
         bucket_name (str): Bucket name to match in case of custom or guardduty types.
         creation_date (datetime): Date to use for file creation.
+        region (str): Region where the data will be generated.
         
     Returns:
         DataGenerator: Data generator for the given bucket.
@@ -1183,4 +1209,4 @@ def get_data_generator(bucket_type, bucket_name, creation_date) -> DataGenerator
     elif bucket_type == GUARD_DUTY_TYPE and 'native' in bucket_name:
         bucket_type = NATIVE_GUARD_DUTY_TYPE
 
-    return buckets_data_mapping[bucket_type](date=creation_date)
+    return buckets_data_mapping[bucket_type](date=creation_date, region=region)

--- a/src/wazuh_testing/tools/db_administrator.py
+++ b/src/wazuh_testing/tools/db_administrator.py
@@ -38,7 +38,7 @@ class DatabaseAdministrator:
         return rows
 
 
-    def execute_fetch_one_query(self, query: str) -> list:
+    def execute_fetch_one_query(self, query: str) -> Tuple:
         self.cursor.execute(query)
         row = self.cursor.fetchone()
 

--- a/src/wazuh_testing/utils/database.py
+++ b/src/wazuh_testing/utils/database.py
@@ -134,6 +134,25 @@ def get_sqlite_query_result(db_path: str, query: str) -> List[str]:
         services.control_service('start', daemon=WAZUH_DB_DAEMON)
 
 
+def get_sqlite_fetch_one_query_result(db_path: str, query: str) -> tuple:
+    """Execute a query expecting only one result in a given database and return the result.
+    Args:
+        db_path (str): Path where is located the DB.
+        query (str): SQL query. e.g(SELECT * ..).
+    Returns:
+        result (tuple): Query result row.
+    """
+    services.control_service('stop', daemon=WAZUH_DB_DAEMON)
+
+    try:
+        with DatabaseAdministrator(db_path) as db:
+            records = db.execute_fetch_one_query(query)
+            
+            return records
+    finally:
+        services.control_service('start', daemon=WAZUH_DB_DAEMON)
+
+
 def run_sql_script(database_path: Union[os.PathLike, str], script_path: Union[os.PathLike, str]) -> None:
     """Run SQL script in a database.
     Args:

--- a/src/wazuh_testing/utils/db_queries/aws_db.py
+++ b/src/wazuh_testing/utils/db_queries/aws_db.py
@@ -132,7 +132,6 @@ def get_s3_db_row(table_name) -> S3CloudTrailRow:
     row_type = _get_s3_row_type(table_name)
     query = SELECT_QUERY_TEMPLATE.format(table_name=table_name)
     row = get_sqlite_fetch_one_query_result(S3_CLOUDTRAIL_DB_PATH, query)[0]
-    
     return row_type(*row)
 
 

--- a/src/wazuh_testing/utils/db_queries/aws_db.py
+++ b/src/wazuh_testing/utils/db_queries/aws_db.py
@@ -7,7 +7,7 @@ This module will contain data structures, queries and db utils to manage AWS ser
 """
 
 # Local imports
-from wazuh_testing.utils.database import get_sqlite_query_result, get_fetch_one_query_result
+from wazuh_testing.utils.database import get_sqlite_query_result, get_sqlite_fetch_one_query_result
 from wazuh_testing.constants.paths.aws import S3_CLOUDTRAIL_DB_PATH, AWS_SERVICES_DB_PATH
 
 """ Database data structures  """
@@ -131,8 +131,8 @@ def get_s3_db_row(table_name) -> S3CloudTrailRow:
     """
     row_type = _get_s3_row_type(table_name)
     query = SELECT_QUERY_TEMPLATE.format(table_name=table_name)
-    row = get_fetch_one_query_result(S3_CLOUDTRAIL_DB_PATH, query)
-
+    row = get_sqlite_fetch_one_query_result(S3_CLOUDTRAIL_DB_PATH, query)[0]
+    
     return row_type(*row)
 
 
@@ -150,7 +150,7 @@ def get_multiple_s3_db_row(table_name):
     rows = get_sqlite_query_result(S3_CLOUDTRAIL_DB_PATH, query)
 
     for row in rows:
-        yield row_type(*row)
+        yield row_type(*row.split(', '))
 
 
 def table_exists(table_name, db_path=S3_CLOUDTRAIL_DB_PATH):
@@ -209,7 +209,7 @@ def get_service_db_row(table_name):
     row_type = _get_service_row_type(table_name)
 
     query = SELECT_QUERY_TEMPLATE.format(table_name=table_name)
-    row = get_fetch_one_query_result(AWS_SERVICES_DB_PATH, query)
+    row = get_sqlite_fetch_one_query_result(AWS_SERVICES_DB_PATH, query)
 
     return row_type(*row)
 
@@ -229,4 +229,4 @@ def get_multiple_service_db_row(table_name):
     rows = get_sqlite_query_result(AWS_SERVICES_DB_PATH, query)
 
     for row in rows:
-        yield row_type(*row)
+        yield row_type(*row.split(', '))


### PR DESCRIPTION
# Description

Closes #150. 
- Modifies S3 data generation methods and functions to generate resources for any specified region with the possibility to include `prefix` or `suffix`.
- Removes the `boto3` client instantiations from the framework, making it the responsibility of the executed tests to instantiate and pass them accordingly.
- Fixes related AWS database functions that were not correctly used after the rebase of the epic branch.

## Tests

<details><summary>Current working tests execution</summary>

```console
root@vagrant:/# pytest -x /wazuh/tests/integration/test_aws/test_log_groups.py 
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0
rootdir: /wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 2 items                                                                                                                                          

wazuh/tests/integration/test_aws/test_log_groups.py ..                                                                                               [100%]

==================================================================== 2 passed in 53.73s ====================================================================
root@vagrant:/# pytest -x /wazuh/tests/integration/test_aws/test_discard_regex.py
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0
rootdir: /wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 17 items                                                                                                                                         

wazuh/tests/integration/test_aws/test_discard_regex.py .................                                                                             [100%]

============================================================== 17 passed in 416.51s (0:06:56) ==============================================================
root@vagrant:/# pytest -x /wazuh/tests/integration/test_aws/test_basic.py 
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0
rootdir: /wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 16 items                                                                                                                                         

wazuh/tests/integration/test_aws/test_basic.py ................                                                                                      [100%]

============================================================== 16 passed in 310.19s (0:05:10) ==============================================================
root@vagrant:/# pytest -x /wazuh/tests/integration/test_aws/test_custom_bucket.py 
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-7.1.2, pluggy-1.4.0
rootdir: /wazuh/tests/integration, configfile: pytest.ini
plugins: metadata-3.1.1, html-3.1.1
collected 2 items                                                                                                                                          

wazuh/tests/integration/test_aws/test_custom_bucket.py ..                                                                                            [100%]

=============================================================== 2 passed in 80.79s (0:01:20) ===============================================================
```

</details> 