### PR TITLE
Add python unit tests coverage script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 chardet==3.0.4
+coverage==7.3.2
 filetype>=1.0.7
 jsonschema==3.2.0
 psutil>=5.6.6
@@ -8,6 +9,7 @@ pyOpenSSL>=19.1.0
 pytest-html==3.1.1
 pytest==6.2.2 ; python_version <= "3.9"
 pytest==7.1.2 ; python_version >= "3.10"
+pytest-cov==4.1.0
 pyyaml>=6.0.1
 requests>=2.23.0
 pywin32>=305; sys_platform == "win32"

--- a/src/wazuh_testing/scripts/pytest_coverage.py
+++ b/src/wazuh_testing/scripts/pytest_coverage.py
@@ -1,0 +1,91 @@
+import argparse
+import re
+import subprocess
+from os import chdir, remove
+from os.path import basename, exists, join, dirname
+
+PYTHON_MODULES = (
+    'framework',  # Framework
+    'api/api',  # API
+    'wodles',  # External modules
+    'integrations'  # Integrations
+)
+
+COVERAGE_FILE = '.coverage'
+COVERAGE_REPORT = ''
+COVERAGE_REGEX = r'^([\w\/._-]+) +(\d+) +(\d+) +(\d+)\%$'
+GLOBAL_STMTS = 0
+GLOBAL_MISS = 0
+TABLE_HEADER = """| | | | | |
+|--|--|--|--|--|
+| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
+"""
+
+
+def obtain_coverage(module):
+    chdir(dirname(module))
+    module_basename = basename(module)
+
+    module_report = f'### {module_basename.upper()}\n\n{TABLE_HEADER}'
+    subprocess.run(['coverage', 'run', '--omit=*test*', '--source', module_basename,
+                    '-m', 'pytest', module_basename],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    coverage_result = subprocess.check_output(['coverage', 'report']).decode().strip()
+    test_coverage_results = re.findall(COVERAGE_REGEX, coverage_result, re.MULTILINE)
+    for test in test_coverage_results:
+        # test_name stmts miss cover
+        coverage = int(test[3])
+        if coverage >= 75:
+            check = ':green_square:'
+        elif coverage >= 50:
+            check = ':yellow_square:'
+        elif coverage >= 25:
+            check = ':orange_square:'
+        else:
+            check = ':red_square:'
+
+        module_report = f'{module_report}| {test[0]} | {test[1]} | {test[2]} | {coverage}% | {check} |\n'
+
+    global COVERAGE_REPORT
+    COVERAGE_REPORT = f'{COVERAGE_REPORT}{module_report}\n'
+
+    global GLOBAL_STMTS, GLOBAL_MISS
+    GLOBAL_STMTS += int(test_coverage_results[-1][1])
+    GLOBAL_MISS += int(test_coverage_results[-1][2])
+
+    # Remove .coverage file
+    exists(COVERAGE_FILE) and remove(COVERAGE_FILE)
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description='Pytest Coverage (Wazuh)')
+    parser.add_argument('-p', '--path', dest='wazuh_path', action='store', required=True,
+                        help='Path to the Wazuh repository.')
+
+    return parser.parse_args()
+
+
+def main():
+    arguments = parse_arguments()
+    wazuh_path = arguments.wazuh_path
+
+    if not exists(wazuh_path):
+        print(f'Base Wazuh path is not valid: {wazuh_path}')
+        exit(1)
+
+    for module in PYTHON_MODULES:
+        current_module_path = join(wazuh_path, module)
+
+        if not exists(current_module_path):
+            print(f'Wazuh module path is not valid: {current_module_path}')
+            exit(1)
+
+        obtain_coverage(current_module_path)
+
+    print(COVERAGE_REPORT)
+    print(f'\nOVERALL COVERAGE PERCENTAGE: {100 - int(GLOBAL_MISS * 100 / GLOBAL_STMTS)}%')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh/issues/23558 |

## Description

Adds a script and the dependencies to get the Python unit tests coverage.

### Tests

https://github.com/wazuh/wazuh/actions/workflows/python-unit-tests-coverage.yml

> The `Run workflow` option appears only after it's merged.

<details><summary>Results</summary>

### FRAMEWORK

| | | | | |
|--|--|--|--|--|
| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
| framework/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/scripts/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/scripts/agent_groups.py | 177 | 17 | 90% | :green_square: |
| framework/scripts/agent_upgrade.py | 115 | 9 | 92% | :green_square: |
| framework/scripts/cluster_control.py | 133 | 1 | 99% | :green_square: |
| framework/scripts/rbac_control.py | 64 | 10 | 84% | :green_square: |
| framework/scripts/wazuh_clusterd.py | 123 | 14 | 89% | :green_square: |
| framework/setup.py | 3 | 3 | 0% | :red_square: |
| framework/wazuh/__init__.py | 50 | 13 | 74% | :yellow_square: |
| framework/wazuh/__main__.py | 2 | 2 | 0% | :red_square: |
| framework/wazuh/active_response.py | 25 | 0 | 100% | :green_square: |
| framework/wazuh/agent.py | 513 | 7 | 99% | :green_square: |
| framework/wazuh/cdb_list.py | 77 | 2 | 97% | :green_square: |
| framework/wazuh/ciscat.py | 27 | 0 | 100% | :green_square: |
| framework/wazuh/cluster.py | 64 | 0 | 100% | :green_square: |
| framework/wazuh/core/InputValidator.py | 19 | 0 | 100% | :green_square: |
| framework/wazuh/core/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/wazuh/core/active_response.py | 70 | 3 | 96% | :green_square: |
| framework/wazuh/core/agent.py | 505 | 30 | 94% | :green_square: |
| framework/wazuh/core/cdb_list.py | 106 | 2 | 98% | :green_square: |
| framework/wazuh/core/cluster/__init__.py | 5 | 0 | 100% | :green_square: |
| framework/wazuh/core/cluster/client.py | 165 | 10 | 94% | :green_square: |
| framework/wazuh/core/cluster/cluster.py | 287 | 2 | 99% | :green_square: |
| framework/wazuh/core/cluster/common.py | 682 | 15 | 98% | :green_square: |
| framework/wazuh/core/cluster/control.py | 63 | 0 | 100% | :green_square: |
| framework/wazuh/core/cluster/dapi/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/wazuh/core/cluster/dapi/dapi.py | 387 | 30 | 92% | :green_square: |
| framework/wazuh/core/cluster/local_client.py | 115 | 6 | 95% | :green_square: |
| framework/wazuh/core/cluster/local_server.py | 152 | 1 | 99% | :green_square: |
| framework/wazuh/core/cluster/master.py | 419 | 5 | 99% | :green_square: |
| framework/wazuh/core/cluster/server.py | 203 | 4 | 98% | :green_square: |
| framework/wazuh/core/cluster/tests/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/wazuh/core/cluster/utils.py | 163 | 0 | 100% | :green_square: |
| framework/wazuh/core/cluster/worker.py | 332 | 12 | 96% | :green_square: |
| framework/wazuh/core/common.py | 127 | 2 | 98% | :green_square: |
| framework/wazuh/core/configuration.py | 514 | 11 | 98% | :green_square: |
| framework/wazuh/core/decoder.py | 52 | 0 | 100% | :green_square: |
| framework/wazuh/core/exception.py | 116 | 3 | 97% | :green_square: |
| framework/wazuh/core/manager.py | 153 | 12 | 92% | :green_square: |
| framework/wazuh/core/mitre.py | 257 | 13 | 95% | :green_square: |
| framework/wazuh/core/pyDaemonModule.py | 64 | 17 | 73% | :yellow_square: |
| framework/wazuh/core/results.py | 335 | 24 | 93% | :green_square: |
| framework/wazuh/core/rootcheck.py | 61 | 0 | 100% | :green_square: |
| framework/wazuh/core/rule.py | 133 | 0 | 100% | :green_square: |
| framework/wazuh/core/sca.py | 78 | 2 | 97% | :green_square: |
| framework/wazuh/core/security.py | 70 | 18 | 74% | :yellow_square: |
| framework/wazuh/core/stats.py | 183 | 6 | 97% | :green_square: |
| framework/wazuh/core/syscheck.py | 28 | 0 | 100% | :green_square: |
| framework/wazuh/core/syscollector.py | 38 | 0 | 100% | :green_square: |
| framework/wazuh/core/task.py | 37 | 0 | 100% | :green_square: |
| framework/wazuh/core/tests/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/wazuh/core/utils.py | 1014 | 51 | 95% | :green_square: |
| framework/wazuh/core/wazuh_queue.py | 82 | 2 | 98% | :green_square: |
| framework/wazuh/core/wazuh_socket.py | 151 | 43 | 72% | :yellow_square: |
| framework/wazuh/core/wdb.py | 210 | 9 | 96% | :green_square: |
| framework/wazuh/core/wlogging.py | 98 | 3 | 97% | :green_square: |
| framework/wazuh/decoder.py | 160 | 6 | 96% | :green_square: |
| framework/wazuh/event.py | 18 | 0 | 100% | :green_square: |
| framework/wazuh/manager.py | 142 | 17 | 88% | :green_square: |
| framework/wazuh/mitre.py | 53 | 0 | 100% | :green_square: |
| framework/wazuh/rbac/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/wazuh/rbac/auth_context.py | 197 | 37 | 81% | :green_square: |
| framework/wazuh/rbac/decorators.py | 232 | 63 | 73% | :yellow_square: |
| framework/wazuh/rbac/orm.py | 1295 | 319 | 75% | :green_square: |
| framework/wazuh/rbac/preprocessor.py | 73 | 22 | 70% | :yellow_square: |
| framework/wazuh/rbac/tests/__init__.py | 0 | 0 | 100% | :green_square: |
| framework/wazuh/rbac/tests/utils.py | 36 | 0 | 100% | :green_square: |
| framework/wazuh/rbac/utils.py | 23 | 10 | 57% | :yellow_square: |
| framework/wazuh/rootcheck.py | 64 | 3 | 95% | :green_square: |
| framework/wazuh/rule.py | 176 | 6 | 97% | :green_square: |
| framework/wazuh/sca.py | 63 | 3 | 95% | :green_square: |
| framework/wazuh/security.py | 552 | 203 | 63% | :yellow_square: |
| framework/wazuh/stats.py | 122 | 8 | 93% | :green_square: |
| framework/wazuh/syscheck.py | 94 | 4 | 96% | :green_square: |
| framework/wazuh/syscollector.py | 35 | 8 | 77% | :green_square: |
| framework/wazuh/task.py | 19 | 0 | 100% | :green_square: |
| framework/wazuh/tests/util.py | 42 | 2 | 95% | :green_square: |
| TOTAL | 12243 | 1125 | 91% | :green_square: |

### API

| | | | | |
|--|--|--|--|--|
| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
| api/__init__.py | 0 | 0 | 100% | :green_square: |
| api/alogging.py | 78 | 0 | 100% | :green_square: |
| api/api_exception.py | 12 | 0 | 100% | :green_square: |
| api/authentication.py | 109 | 7 | 94% | :green_square: |
| api/configuration.py | 94 | 4 | 96% | :green_square: |
| api/constants.py | 14 | 0 | 100% | :green_square: |
| api/controllers/__init__.py | 0 | 0 | 100% | :green_square: |
| api/controllers/active_response_controller.py | 15 | 0 | 100% | :green_square: |
| api/controllers/agent_controller.py | 248 | 6 | 98% | :green_square: |
| api/controllers/cdb_list_controller.py | 41 | 0 | 100% | :green_square: |
| api/controllers/ciscat_controller.py | 13 | 0 | 100% | :green_square: |
| api/controllers/cluster_controller.py | 163 | 0 | 100% | :green_square: |
| api/controllers/decoder_controller.py | 46 | 0 | 100% | :green_square: |
| api/controllers/default_controller.py | 16 | 0 | 100% | :green_square: |
| api/controllers/event_controller.py | 15 | 0 | 100% | :green_square: |
| api/controllers/experimental_controller.py | 119 | 0 | 100% | :green_square: |
| api/controllers/manager_controller.py | 120 | 0 | 100% | :green_square: |
| api/controllers/mitre_controller.py | 41 | 0 | 100% | :green_square: |
| api/controllers/overview_controller.py | 12 | 0 | 100% | :green_square: |
| api/controllers/rootcheck_controller.py | 27 | 0 | 100% | :green_square: |
| api/controllers/rule_controller.py | 58 | 0 | 100% | :green_square: |
| api/controllers/sca_controller.py | 20 | 0 | 100% | :green_square: |
| api/controllers/security_controller.py | 245 | 9 | 96% | :green_square: |
| api/controllers/syscheck_controller.py | 33 | 0 | 100% | :green_square: |
| api/controllers/syscollector_controller.py | 74 | 0 | 100% | :green_square: |
| api/controllers/task_controller.py | 13 | 0 | 100% | :green_square: |
| api/controllers/test/utils.py | 11 | 0 | 100% | :green_square: |
| api/encoder.py | 24 | 1 | 96% | :green_square: |
| api/middlewares.py | 104 | 37 | 64% | :yellow_square: |
| api/models/__init__.py | 3 | 0 | 100% | :green_square: |
| api/models/active_response_model.py | 29 | 0 | 100% | :green_square: |
| api/models/agent_added_model.py | 72 | 0 | 100% | :green_square: |
| api/models/agent_group_added_model.py | 15 | 0 | 100% | :green_square: |
| api/models/agent_inserted_model.py | 50 | 0 | 100% | :green_square: |
| api/models/base_model_.py | 104 | 0 | 100% | :green_square: |
| api/models/basic_info_model.py | 59 | 0 | 100% | :green_square: |
| api/models/configuration_model.py | 205 | 0 | 100% | :green_square: |
| api/models/event_ingest_model.py | 17 | 0 | 100% | :green_square: |
| api/models/security_model.py | 72 | 0 | 100% | :green_square: |
| api/models/security_token_response_model.py | 19 | 0 | 100% | :green_square: |
| api/signals.py | 52 | 1 | 98% | :green_square: |
| api/uri_parser.py | 29 | 0 | 100% | :green_square: |
| api/util.py | 152 | 4 | 97% | :green_square: |
| api/validator.py | 163 | 14 | 91% | :green_square: |
| TOTAL | 2806 | 83 | 97% | :green_square: |

### WODLES

| | | | | |
|--|--|--|--|--|
| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
| wodles/__init__.py | 0 | 0 | 100% | :green_square: |
| wodles/aws/__init__.py | 0 | 0 | 100% | :green_square: |
| wodles/aws/aws_s3.py | 94 | 18 | 81% | :green_square: |
| wodles/aws/aws_tools.py | 147 | 15 | 90% | :green_square: |
| wodles/aws/buckets_s3/__init__.py | 10 | 0 | 100% | :green_square: |
| wodles/aws/buckets_s3/aws_bucket.py | 426 | 16 | 96% | :green_square: |
| wodles/aws/buckets_s3/cloudtrail.py | 26 | 3 | 88% | :green_square: |
| wodles/aws/buckets_s3/config.py | 91 | 7 | 92% | :green_square: |
| wodles/aws/buckets_s3/guardduty.py | 64 | 1 | 98% | :green_square: |
| wodles/aws/buckets_s3/load_balancers.py | 69 | 0 | 100% | :green_square: |
| wodles/aws/buckets_s3/server_access.py | 137 | 12 | 91% | :green_square: |
| wodles/aws/buckets_s3/umbrella.py | 22 | 0 | 100% | :green_square: |
| wodles/aws/buckets_s3/vpcflow.py | 102 | 15 | 85% | :green_square: |
| wodles/aws/buckets_s3/waf.py | 38 | 0 | 100% | :green_square: |
| wodles/aws/services/__init__.py | 4 | 0 | 100% | :green_square: |
| wodles/aws/services/aws_service.py | 45 | 0 | 100% | :green_square: |
| wodles/aws/services/cloudwatchlogs.py | 191 | 7 | 96% | :green_square: |
| wodles/aws/services/inspector.py | 56 | 6 | 89% | :green_square: |
| wodles/aws/subscribers/__init__.py | 4 | 0 | 100% | :green_square: |
| wodles/aws/subscribers/s3_log_handler.py | 114 | 12 | 89% | :green_square: |
| wodles/aws/subscribers/sqs_message_processor.py | 35 | 1 | 97% | :green_square: |
| wodles/aws/subscribers/sqs_queue.py | 60 | 7 | 88% | :green_square: |
| wodles/aws/tests/__init__.py | 0 | 0 | 100% | :green_square: |
| wodles/aws/tests/aws_utils.py | 113 | 0 | 100% | :green_square: |
| wodles/aws/wazuh_integration.py | 231 | 20 | 91% | :green_square: |
| wodles/azure/azure-logs.py | 437 | 36 | 92% | :green_square: |
| wodles/azure/orm.py | 141 | 0 | 100% | :green_square: |
| wodles/docker-listener/DockerListener.py | 93 | 6 | 94% | :green_square: |
| wodles/gcloud/buckets/access_logs.py | 16 | 0 | 100% | :green_square: |
| wodles/gcloud/buckets/bucket.py | 128 | 2 | 98% | :green_square: |
| wodles/gcloud/exceptions.py | 23 | 0 | 100% | :green_square: |
| wodles/gcloud/gcloud.py | 68 | 1 | 99% | :green_square: |
| wodles/gcloud/integration.py | 38 | 2 | 95% | :green_square: |
| wodles/gcloud/pubsub/subscriber.py | 60 | 2 | 97% | :green_square: |
| wodles/gcloud/tools.py | 41 | 0 | 100% | :green_square: |
| wodles/utils.py | 58 | 27 | 53% | :yellow_square: |
| TOTAL | 3182 | 216 | 93% | :green_square: |

### INTEGRATIONS

| | | | | |
|--|--|--|--|--|
| **Name** | **Stmts** | **Miss** | **Cover** | **Status** |
| integrations/maltiverse.py | 197 | 15 | 92% | :green_square: |
| integrations/pagerduty.py | 102 | 21 | 79% | :green_square: |
| integrations/shuffle.py | 103 | 7 | 93% | :green_square: |
| integrations/slack.py | 110 | 30 | 73% | :yellow_square: |
| integrations/tests/__init__.py | 0 | 0 | 100% | :green_square: |
| integrations/virustotal.py | 163 | 43 | 74% | :yellow_square: |
| TOTAL | 675 | 116 | 83% | :green_square: |



OVERALL COVERAGE PERCENTAGE: 92%

</details>