### PR TITLE
Upgrade ´py´ module in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ coverage==7.3.2
 filetype>=1.0.7
 jsonschema==3.2.0
 psutil>=5.6.6
-py~=1.10.0
+py~=1.11.0
 pycryptodome>=3.18.0
 pyOpenSSL>=19.1.0
 pytest-html==3.1.1


### PR DESCRIPTION
# Description

Issue related: https://github.com/wazuh/wazuh/issues/23148

In this PR we are modifying the required version of the py module in order to support the macOS integration tests, which now have python version 3.11.