### PR TITLE
New regex callback in FIM tests to find events for invalid path names

### DIFF
--- a/src/wazuh_testing/modules/fim/patterns.py
+++ b/src/wazuh_testing/modules/fim/patterns.py
@@ -8,6 +8,8 @@ IGNORING_DUE_TO_PATTERN = r".*?Ignoring path '(.*)' due to pattern '(.*)'.*"
 IGNORING_DUE_TO_RESTRICTION = r".*Ignoring entry '(.*?)' due to restriction '.*?'"
 REALTIME_WHODATA_ENGINE_STARTED = r'.*File integrity monitoring real-time Whodata engine started.*'
 MONITORING_PATH = r'.*Monitoring path:.*'
+IGNORING_DUE_TO_INVALID_NAME = r".*Ignoring file '(.*)' due to unsupported name.*"
+SYNC_INTEGRITY_MESSAGE = r".*Sending integrity control message: {(.*)}.*"
 
 NUM_INOTIFY_WATCHES = r'.*Folders monitored with real-time engine: (\d+)'
 PATH_MONITORED_REALTIME = r".*Directory added for real time monitoring: (.*)"


### PR DESCRIPTION
# Description

In this PR we are adding the following callback pattern to detect warnings related to unsupported name (nonUTF8)
`IGNORING_DUE_TO_INVALID_NAME = r".*Ignoring file '(.*)' due to unsupported name.*"`

## Testing
Testing will be done in the related wazuh/wazuh PR which includes tests:
