### PR TITLE
Adapt regex for double IP stack

### DIFF
--- a/src/wazuh_testing/modules/api/patterns.py
+++ b/src/wazuh_testing/modules/api/patterns.py
@@ -4,7 +4,7 @@ Created by Wazuh, Inc. <info@wazuh.com>.
 This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
 # Regular expressions
-API_STARTED_MSG = r'.*Listening on {host}:{port}.+'
+API_STARTED_MSG = r'.*Listening on \{host}:{port}.+'
 API_TIMEOUT_ERROR_MSG = r'.*ERROR.*Timeout executing API request.*'
 API_LOGIN_REQUEST_MSG = r'.*INFO.*{user}.*{host}.*{login_route}.*'
 


### PR DESCRIPTION
Adds an escape character to match the new log format for the API start-up correctly.

```console
2024/08/20 13:07:31 INFO: Listening on ['0.0.0.0', '::']:55000.
```