### PR TITLE
Add version file for package installation

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-    "version": "4.22.0",
+    "version": "4.12.0",
     "stage": "alpha0"
 }

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,0 +1,4 @@
+{
+    "version": "4.22.0",
+    "stage": "alpha0"
+}

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ This program is free software; you can redistribute it and/or modify it under th
 """
 import shutil
 
+import json
 from pathlib import Path
 from setuptools import setup, find_packages
 from typing import List
@@ -59,9 +60,18 @@ def get_install_requires() -> List[str]:
     return targets
 
 
+def get_version_from_json() -> str:
+    version_file = 'VERSION.json'
+
+    fname = Path(__file__).parent / version_file
+    with open(fname, 'r', encoding='utf-8') as file:
+        data = json.load(file)
+    return data.get("version", "")
+
+
 setup(
     name='wazuh_testing',
-    version='4.12.0',
+    version=get_version_from_json(),
     description='Wazuh testing utilities to help programmers automate tests',
     url='https://github.com/wazuh',
     author='Wazuh',


### PR DESCRIPTION
|Related issue|
|--|
| #302 |

## Description

Adds the `VERSION.json` file to comply with the standardization of how the Wazuh repositories handle versions and revisions. It also modifies the `setup.py` file to get the package's version from the newly added file.