### PR TITLE
Add bumper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ dist/
 *.egg-info/
 venv
 dist
+
+tools/repository_bumper_*.log

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-    "version": "4.13.0",
-    "stage": "alpha0"
+  "version": "4.13.0",
+  "stage": "alpha0"
 }

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check for the correct number of arguments
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <new_version> <stage>"
+    exit 1
+fi
+
+NEW_VERSION="$1"
+STAGE="$2"
+VERSION_FILE="VERSION.json"
+LOGFILE="tools/repository_bumper_$(date +'%Y-%m-%d_%H-%M-%S').log"
+
+# Check if version.json exists
+if [ ! -f "$VERSION_FILE" ]; then
+    echo "Version file not found!"
+    exit 1
+fi
+
+# Read the current version and stage from the JSON file
+CURRENT_VERSION=$(jq -r '.version' "$VERSION_FILE")
+CURRENT_STAGE=$(jq -r '.stage' "$VERSION_FILE")
+
+echo "Current version: $CURRENT_VERSION"
+echo "Current stage: $CURRENT_STAGE"
+
+# Update the JSON file with the new version and stage
+jq --arg new_version "$NEW_VERSION" --arg new_stage "$STAGE" \
+   '.version = $new_version | .stage = $new_stage' "$VERSION_FILE" > tmp.$.json && mv tmp.$.json "$VERSION_FILE"
+
+# Log the changes
+echo "Modified files:" > "$LOGFILE"
+echo "$VERSION_FILE: version $CURRENT_VERSION -> $NEW_VERSION, stage $CURRENT_STAGE -> $STAGE" >> "$LOGFILE"

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -7,7 +7,7 @@ if [ "$#" -ne 2 ]; then
 fi
 
 NEW_VERSION="$1"
-STAGE="$2"
+NEW_STAGE="$2"
 VERSION_FILE="VERSION.json"
 LOGFILE="tools/repository_bumper_$(date +'%Y-%m-%d_%H-%M-%S').log"
 
@@ -25,9 +25,9 @@ echo "Current version: $CURRENT_VERSION"
 echo "Current stage: $CURRENT_STAGE"
 
 # Update the JSON file with the new version and stage
-jq --arg new_version "$NEW_VERSION" --arg new_stage "$STAGE" \
+jq --arg new_version "$NEW_VERSION" --arg new_stage "$NEW_STAGE" \
    '.version = $new_version | .stage = $new_stage' "$VERSION_FILE" > tmp.$.json && mv tmp.$.json "$VERSION_FILE"
 
 # Log the changes
-echo "Modified files:" > "$LOGFILE"
-echo "$VERSION_FILE: version $CURRENT_VERSION -> $NEW_VERSION, stage $CURRENT_STAGE -> $STAGE" >> "$LOGFILE"
+echo "Modified files:" | tee "$LOGFILE"
+echo "$VERSION_FILE: version $CURRENT_VERSION -> $NEW_VERSION, stage $CURRENT_STAGE -> $NEW_STAGE" | tee -a "$LOGFILE"


### PR DESCRIPTION
## Description

This PR closes #341. Adds a script to bump the version and revision of `VERSION.json`.

```console
➜  qa-integration-framework git:(enhancement/341-bumper-script) ./tools/repository_bumper.sh --help
Usage: ./tools/repository_bumper.sh <new_version> <stage>
```

```console
➜  qa-integration-framework git:(enhancement/341-bumper-script) ./tools/repository_bumper.sh 4.13.0 alpha1
Current version: 4.13.0
Current stage: alpha0
➜  qa-integration-framework git:(enhancement/341-bumper-script) ✗ cat tools/repository_bumper_2025-04-11_17-30-01.log
Modified files:
VERSION.json: version 4.13.0 -> 4.13.0, stage alpha0 -> alpha1
```

```diff
diff --git a/VERSION.json b/VERSION.json
index 4d32c49..3747a84 100644
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.13.0",
-  "stage": "alpha0"
+  "stage": "alpha1"
 }
```