### PR TITLE
Revert automatic default group assignment in agent creation mock

### DIFF
--- a/src/wazuh_testing/utils/mocking.py
+++ b/src/wazuh_testing/utils/mocking.py
@@ -233,7 +233,7 @@ def create_mocked_agent(id=None, name='centos8-agent', ip='127.0.0.1', register_
                         os_build='4.18.0-147.8.1.el8_1.x86_64', os_platform='#1 SMP Thu Apr 9 13:49:54 UTC 2020',
                         os_uname='x64', os_arch='x64', version='Wazuh v4.3.0', config_sum='', merged_sum='',
                         manager_host='centos-8', node_name='node01', date_add='1612942494', hostname='centos-8',
-                        last_keepalive='253402300799', group='default', sync_status='synced', connection_status='active',
+                        last_keepalive='253402300799', group='', sync_status='synced', connection_status='active',
                         client_key_secret=None, os_release='', os_patch='', release='', sysname='Linux',
                         checksum='checksum', os_display_version='', reference='', disconnection_time='0',
                         architecture='x64'):


### PR DESCRIPTION
## Description

This pull request reverts the changes that updated the agent creation mock to assign the `"default"` group by default when no group was explicitly specified. These changes were initially introduced to align the QA framework with a Wazuh manager behavior that has now been reverted due to issues caused in cluster synchronization.

As the manager no longer assigns the `"default"` group by default at registration, the QA framework should revert to the previous behavior to maintain consistency and avoid invalid test assumptions.

## Proposed Changes

- Revert modifications to the agent creation mock logic that enforced a default group assignment.
- Restore the original behavior where agents are created with `group = None` unless explicitly specified.
- Revert any test fixtures or helper functions adjusted as part of the previous change.

### Results and Evidence

- Agents created without an explicitly defined group are now consistent with current manager behavior (`group = None`).
- All integration tests remain valid after the revert.

### Related issues

- https://github.com/wazuh/wazuh/issues/29401
- https://github.com/wazuh/qa-integration-framework/pull/348

#### Local Authd integration tests

```
test_authd_local.py::test_authd_local_messages[Add agent] PASSED           [ 12%]
test_authd_local.py::test_authd_local_messages[Add duplicate agent without force options in request] PASSED [ 25%]
test_authd_local.py::test_authd_local_messages[Failed duplicate registration] PASSED [ 37%]
test_authd_local.py::test_authd_local_messages[Force registration] PASSED  [ 50%]
test_authd_local.py::test_authd_local_messages[Single/Multi Group] PASSED  [ 62%]
test_authd_local.py::test_authd_local_messages[Remove agent] PASSED        [ 75%]
test_authd_local.py::test_authd_local_messages[Agent with key hash simple] PASSED [ 87%]
test_authd_local.py::test_authd_local_messages[Agent with key hash and group] PASSED [100%]
```

### Artifacts Affected

- Agent creation mock functions
- Related test fixtures using default group assignment logic

### Configuration Changes

No configuration changes required.

### Documentation Updates

Not applicable.

### Tests Introduced

No new tests introduced.

Existing tests continue to validate behavior under the reverted logic.

## Review Checklist

- [x] Code changes reviewed  
- [x] Relevant evidence provided  
- [x] Tests remain valid with the reverted mock  
- [x] Configuration changes documented (if any)  
- [x] QA framework remains aligned with manager logic  
- [x] No impact on unrelated test cases  