### PR TITLE
Ruleset correction in ossec.conf

### DIFF
--- a/src/wazuh_testing/data/configuration_template/all_disabled_ossec.conf
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_ossec.conf
@@ -55,6 +55,9 @@
     <list>etc/lists/audit-keys</list>
     <list>etc/lists/amazon/aws-eventnames</list>
     <list>etc/lists/security-eventchannel</list>
+    <list>etc/lists/malicious-ioc/malware-hashes</list>
+    <list>etc/lists/malicious-ioc/malicious-ip</list>
+    <list>etc/lists/malicious-ioc/malicious-domains</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>


### PR DESCRIPTION
## Description

The test configuration template (all_disabled_ossec.conf) was missing the necessary entries to properly load the indicators of compromise (IOC) lists used by custom rules with if_sid. This caused SIDs 99905 and 99906 to not be found in analysisd, and the test_valid_signature_id integration test to fail with the message "Signature ID '…' was not found."

With these changes, analysisd will be able to load the referenced rules before evaluating if_sid, and the test will pass successfully.