### PR TITLE
Added an admin flag to the repository bumper workflow merge action

### DIFF
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Merge pull request
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
-          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge
+          gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
 
       - name: Show logs
         run: |


### PR DESCRIPTION
## Description

This PR adds the `--admin` flag to the merge action of the repository bumper workflow due to the restriction applied to the numbered branches, as currently the following error is preventing the automatic merge

```
X Pull request wazuh/wazuh-qa-automation#2215 is not mergeable: the base branch policy prohibits the merge.
To have the pull request merged after all the requirements have been met, add the `--auto` flag.
To use administrator privileges to immediately merge the pull request, add the `--admin` flag.
```

This change has been tested with the wazuh-qa-automation repository https://github.com/wazuh/wazuh-qa-automation/pull/2218