### PR TITLE
Remove osquery references

### DIFF
--- a/src/wazuh_testing/data/configuration_template/all_disabled_ossec.conf
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_ossec.conf
@@ -24,11 +24,6 @@
     <disabled>yes</disabled>
   </wodle>
 
-  <!-- Osquery integration -->
-  <wodle name="osquery">
-    <disabled>yes</disabled>
-  </wodle>
-
   <!-- System inventory -->
   <wodle name="syscollector">
     <disabled>yes</disabled>

--- a/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-analysisd_template.json
@@ -115,9 +115,6 @@
                                               "oscap": {
                                                 "type": "integer"
                                               },
-                                              "osquery": {
-                                                "type": "integer"
-                                              },
                                               "rootcheck": {
                                                 "type": "integer"
                                               },
@@ -148,7 +145,6 @@
                                               "logcollector_breakdown",
                                               "office365",
                                               "oscap",
-                                              "osquery",
                                               "rootcheck",
                                               "sca",
                                               "syscheck",

--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-analysisd_template.json
@@ -142,9 +142,6 @@
                                       "oscap": {
                                         "type": "integer"
                                       },
-                                      "osquery": {
-                                        "type": "integer"
-                                      },
                                       "rootcheck": {
                                         "type": "integer"
                                       },
@@ -175,7 +172,6 @@
                                       "logcollector_breakdown",
                                       "office365",
                                       "oscap",
-                                      "osquery",
                                       "rootcheck",
                                       "sca",
                                       "syscheck",
@@ -281,9 +277,6 @@
                                       "oscap": {
                                         "type": "integer"
                                       },
-                                      "osquery": {
-                                        "type": "integer"
-                                      },
                                       "rootcheck": {
                                         "type": "integer"
                                       },
@@ -314,7 +307,6 @@
                                       "logcollector_breakdown",
                                       "office365",
                                       "oscap",
-                                      "osquery",
                                       "rootcheck",
                                       "sca",
                                       "syscheck",


### PR DESCRIPTION
|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/issues/30910|

## Description

Hi team,

This PR removes the use of the deprecated `osquery` wodle in the integration tests framework.
