### PR TITLE
Remove ciscat references

### DIFF
--- a/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-analysisd_template.json
@@ -71,9 +71,6 @@
                                               "azure": {
                                                 "type": "integer"
                                               },
-                                              "ciscat": {
-                                                "type": "integer"
-                                              },
                                               "command": {
                                                 "type": "integer"
                                               },
@@ -140,7 +137,6 @@
                                             "required": [
                                               "aws",
                                               "azure",
-                                              "ciscat",
                                               "command",
                                               "docker",
                                               "gcp",

--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-analysisd_template.json
@@ -98,9 +98,6 @@
                                       "azure": {
                                         "type": "integer"
                                       },
-                                      "ciscat": {
-                                        "type": "integer"
-                                      },
                                       "command": {
                                         "type": "integer"
                                       },
@@ -167,7 +164,6 @@
                                     "required": [
                                       "aws",
                                       "azure",
-                                      "ciscat",
                                       "command",
                                       "docker",
                                       "gcp",
@@ -237,9 +233,6 @@
                                       "azure": {
                                         "type": "integer"
                                       },
-                                      "ciscat": {
-                                        "type": "integer"
-                                      },
                                       "command": {
                                         "type": "integer"
                                       },
@@ -306,7 +299,6 @@
                                     "required": [
                                       "aws",
                                       "azure",
-                                      "ciscat",
                                       "command",
                                       "docker",
                                       "gcp",

--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
@@ -77,17 +77,6 @@
                                   "tables": {
                                     "type": "object",
                                     "properties": {
-                                      "ciscat": {
-                                        "type": "object",
-                                        "properties": {
-                                          "ciscat": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "ciscat"
-                                        ]
-                                      },
                                       "rootcheck": {
                                         "type": "object",
                                         "properties": {
@@ -229,7 +218,6 @@
                                       }
                                     },
                                     "required": [
-                                      "ciscat",
                                       "rootcheck",
                                       "sca",
                                       "sync",
@@ -608,17 +596,6 @@
                                   "tables": {
                                     "type": "object",
                                     "properties": {
-                                      "ciscat": {
-                                        "type": "object",
-                                        "properties": {
-                                          "ciscat": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "ciscat"
-                                        ]
-                                      },
                                       "rootcheck": {
                                         "type": "object",
                                         "properties": {
@@ -760,7 +737,6 @@
                                       }
                                     },
                                     "required": [
-                                      "ciscat",
                                       "rootcheck",
                                       "sca",
                                       "sync",


### PR DESCRIPTION
|**Related Issue**|
|---|
|https://github.com/wazuh/wazuh/pull/31104|

## Description

Hi team,

This PR removes the use of the deprecated `ciscat` module in the integration tests framework.
