### PR TITLE
Agent cleanup

### DIFF
--- a/src/wazuh_testing/constants/paths/binaries.py
+++ b/src/wazuh_testing/constants/paths/binaries.py
@@ -10,14 +10,10 @@ from . import WAZUH_PATH
 
 if sys.platform == WINDOWS:
     BIN_PATH = WAZUH_PATH
-    AGENT_AUTH_PATH = os.path.join(WAZUH_PATH, 'agent-auth.exe')
 else:
     BIN_PATH = os.path.join(WAZUH_PATH, 'bin')
-    AGENT_AUTH_PATH= os.path.join(BIN_PATH, 'agent-auth')
 
 WAZUH_CONTROL_PATH = os.path.join(BIN_PATH, 'wazuh-control')
-AGENT_AUTH_PATH = os.path.join(BIN_PATH, 'agent-auth')
 ACTIVE_RESPONSE_BIN_PATH = os.path.join(WAZUH_PATH, 'active-response', 'bin')
 ACTIVE_RESPONSE_FIREWALL_DROP = os.path.join(ACTIVE_RESPONSE_BIN_PATH, 'firewall-drop')
-MANAGE_AGENTS_BINARY = os.path.join(BIN_PATH, 'manage_agents')
 AGENT_GROUPS_BINARY = os.path.join(BIN_PATH, 'agent_groups')

--- a/src/wazuh_testing/data/configuration_template/all_disabled_ossec.conf
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_ossec.conf
@@ -24,11 +24,6 @@
     <disabled>yes</disabled>
   </wodle>
 
-  <!-- Osquery integration -->
-  <wodle name="osquery">
-    <disabled>yes</disabled>
-  </wodle>
-
   <!-- System inventory -->
   <wodle name="syscollector">
     <disabled>yes</disabled>

--- a/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-analysisd_template.json
@@ -71,9 +71,6 @@
                                               "azure": {
                                                 "type": "integer"
                                               },
-                                              "ciscat": {
-                                                "type": "integer"
-                                              },
                                               "command": {
                                                 "type": "integer"
                                               },
@@ -115,9 +112,6 @@
                                               "oscap": {
                                                 "type": "integer"
                                               },
-                                              "osquery": {
-                                                "type": "integer"
-                                              },
                                               "rootcheck": {
                                                 "type": "integer"
                                               },
@@ -140,7 +134,6 @@
                                             "required": [
                                               "aws",
                                               "azure",
-                                              "ciscat",
                                               "command",
                                               "docker",
                                               "gcp",
@@ -148,7 +141,6 @@
                                               "logcollector_breakdown",
                                               "office365",
                                               "oscap",
-                                              "osquery",
                                               "rootcheck",
                                               "sca",
                                               "syscheck",

--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-analysisd_template.json
@@ -98,9 +98,6 @@
                                       "azure": {
                                         "type": "integer"
                                       },
-                                      "ciscat": {
-                                        "type": "integer"
-                                      },
                                       "command": {
                                         "type": "integer"
                                       },
@@ -142,9 +139,6 @@
                                       "oscap": {
                                         "type": "integer"
                                       },
-                                      "osquery": {
-                                        "type": "integer"
-                                      },
                                       "rootcheck": {
                                         "type": "integer"
                                       },
@@ -167,7 +161,6 @@
                                     "required": [
                                       "aws",
                                       "azure",
-                                      "ciscat",
                                       "command",
                                       "docker",
                                       "gcp",
@@ -175,7 +168,6 @@
                                       "logcollector_breakdown",
                                       "office365",
                                       "oscap",
-                                      "osquery",
                                       "rootcheck",
                                       "sca",
                                       "syscheck",
@@ -237,9 +229,6 @@
                                       "azure": {
                                         "type": "integer"
                                       },
-                                      "ciscat": {
-                                        "type": "integer"
-                                      },
                                       "command": {
                                         "type": "integer"
                                       },
@@ -281,9 +270,6 @@
                                       "oscap": {
                                         "type": "integer"
                                       },
-                                      "osquery": {
-                                        "type": "integer"
-                                      },
                                       "rootcheck": {
                                         "type": "integer"
                                       },
@@ -306,7 +292,6 @@
                                     "required": [
                                       "aws",
                                       "azure",
-                                      "ciscat",
                                       "command",
                                       "docker",
                                       "gcp",
@@ -314,7 +299,6 @@
                                       "logcollector_breakdown",
                                       "office365",
                                       "oscap",
-                                      "osquery",
                                       "rootcheck",
                                       "sca",
                                       "syscheck",

--- a/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
+++ b/src/wazuh_testing/data/statistics_template/manager_statistics_format_test_module/wazuh-db_template.json
@@ -77,17 +77,6 @@
                                   "tables": {
                                     "type": "object",
                                     "properties": {
-                                      "ciscat": {
-                                        "type": "object",
-                                        "properties": {
-                                          "ciscat": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "ciscat"
-                                        ]
-                                      },
                                       "rootcheck": {
                                         "type": "object",
                                         "properties": {
@@ -229,7 +218,6 @@
                                       }
                                     },
                                     "required": [
-                                      "ciscat",
                                       "rootcheck",
                                       "sca",
                                       "sync",
@@ -608,17 +596,6 @@
                                   "tables": {
                                     "type": "object",
                                     "properties": {
-                                      "ciscat": {
-                                        "type": "object",
-                                        "properties": {
-                                          "ciscat": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "ciscat"
-                                        ]
-                                      },
                                       "rootcheck": {
                                         "type": "object",
                                         "properties": {
@@ -760,7 +737,6 @@
                                       }
                                     },
                                     "required": [
-                                      "ciscat",
                                       "rootcheck",
                                       "sca",
                                       "sync",

--- a/src/wazuh_testing/utils/manage_agents.py
+++ b/src/wazuh_testing/utils/manage_agents.py
@@ -3,13 +3,10 @@ Copyright (C) 2015-2023, Wazuh Inc.
 Created by Wazuh, Inc. <info@wazuh.com>.
 This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 """
-import os
-import subprocess
-import requests
 from typing import List
+import requests
 
 from wazuh_testing.constants.api import AGENTS_ROUTE
-from wazuh_testing.constants.paths.binaries import MANAGE_AGENTS_BINARY
 from wazuh_testing.modules.api.utils import login, get_base_url
 from wazuh_testing.utils.db_queries import global_db
 
@@ -25,17 +22,14 @@ def remove_agents(agents_id: List, remove_type: str = 'wazuhdb') -> None:
         ValueError: When the type of removal is not correct.
         RuntimeError: When the agent could not be removed via API.
     """
-    if remove_type not in ('wazuhdb', 'manage_agents', 'api'):
+    if remove_type not in ('wazuhdb', 'api'):
         raise ValueError(f"Invalid type of agent removal: {remove_type}")
 
     if agents_id:
-        for agent_id in agents_id:
-            if remove_type == 'manage_agents':
-                subprocess.call([MANAGE_AGENTS_BINARY, "-r", f"{agent_id}"], stdout=open(os.devnull, "w"),
-                                stderr=subprocess.STDOUT)
-            elif remove_type == 'wazuhdb':
+        if remove_type == 'wazuhdb':
+            for agent_id in agents_id:
                 global_db.delete_agent(agent_id)
-        if remove_type == 'api':
+        else:
             authentication_headers, _ = login()
             url = get_base_url() + AGENTS_ROUTE
             payload = {


### PR DESCRIPTION
Re-introduces the 4 agent cleanup previously reverted commits. 
[Remove agent-auth references #444](https://github.com/wazuh/qa-integration-framework/pull/444)
[Remove ciscat references #443](https://github.com/wazuh/qa-integration-framework/pull/443)
[Remove osquery references #442](https://github.com/wazuh/qa-integration-framework/pull/442)
[Remove use of deprecated manage_agents binary #439](https://github.com/wazuh/qa-integration-framework/pull/439)

This reverts commit 1ba15af15beaae3332f78f77477ab75cdbfc8d7a, reversing changes made to 60811f1cb0263bbce342369e80c87297118b0285.