### PR TITLE
Remove integrations from test coverage

### DIFF
--- a/src/wazuh_testing/scripts/pytest_coverage.py
+++ b/src/wazuh_testing/scripts/pytest_coverage.py
@@ -8,7 +8,6 @@ PYTHON_MODULES = (
     'framework',  # Framework
     'api/api',  # API
     'wodles',  # External modules
-    'integrations'  # Integrations
 )
 
 COVERAGE_FILE = '.coverage'


### PR DESCRIPTION
## Description

Part of https://github.com/wazuh/wazuh/issues/31472. Removes the `integrations` folder from the test coverage script.