### PR TITLE
Remove Tier 3 OS: Deprecate specials

### DIFF
--- a/src/wazuh_testing/constants/platforms.py
+++ b/src/wazuh_testing/constants/platforms.py
@@ -4,7 +4,6 @@
 
 LINUX = 'linux'
 MACOS = 'darwin'
-SOLARIS = 'sunos5'
 WINDOWS = 'win32'
 CENTOS = 'centos'
 UBUNTU = 'ubuntu'

--- a/src/wazuh_testing/data/events_template/keepalives.txt
+++ b/src/wazuh_testing/data/events_template/keepalives.txt
@@ -1,7 +1,3 @@
-solaris11
-#!-SunOS |agent-solaris11 |5.11 |11.3 |i86pc [SunOS|sunos: 11.3] - Wazuh <VERSION> / ab73af41699f13fdd81903b5f23d8d00
-<MERGED_CHECKSUM> merged.mg
-#"_agent_ip":172.16.5.4
 mojave
 #!-Darwin |snaow-imac.home |18.5.0 |Darwin Kernel Version 18.5.0: Mon Mar 11 20:40:32 PDT 2019; root:xnu-4903.251.3~3/RELEASE_X86_64 |x86_64 [Mac OS X|darwin: 10.14.4 (Mojave)] - Wazuh <VERSION> / ab73af41699f13fdd81903b5f23d8d00
 <MERGED_CHECKSUM> merged.mg

--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -36,7 +36,7 @@ from wazuh_testing.utils.random import get_random_ip, get_random_string
 
 
 os_list = ["debian7", "debian8", "debian9", "debian10", "ubuntu12.04",
-           "ubuntu14.04", "ubuntu16.04", "ubuntu18.04", "mojave", "solaris11"]
+           "ubuntu14.04", "ubuntu16.04", "ubuntu18.04", "mojave"]
 agent_count = 1
 
 SYSCOLLECTOR_HEADER = '{"type":"<syscollector_type>",' \

--- a/src/wazuh_testing/utils/services.py
+++ b/src/wazuh_testing/utils/services.py
@@ -14,7 +14,7 @@ from wazuh_testing.constants.daemons import CLUSTER_DAEMON, API_DAEMON, WAZUH_AG
 from wazuh_testing.constants.paths.binaries import BIN_PATH, WAZUH_CONTROL_PATH
 from wazuh_testing.constants.paths.sockets import WAZUH_SOCKETS, WAZUH_OPTIONAL_SOCKETS
 from wazuh_testing.constants.paths.variables import VAR_RUN_PATH, VERSION_FILE
-from wazuh_testing.constants.platforms import MACOS, SOLARIS, WINDOWS
+from wazuh_testing.constants.platforms import MACOS, WINDOWS
 
 from . import sockets
 
@@ -35,7 +35,7 @@ def get_service() -> str:
     if platform.system() in ['Windows', WINDOWS]:
         return WAZUH_AGENT
 
-    else:  # Linux, sunos5, darwin, aix...
+    else:  # Linux, darwin...
         service = subprocess.check_output([
             WAZUH_CONTROL_PATH, "info", "-t"
         ], stderr=subprocess.PIPE).decode('utf-8').strip()
@@ -62,7 +62,7 @@ def get_version() -> str:
             version = data.get("version", "")
             return f"v{version}"
 
-    else:  # Linux, sunos5, darwin, aix...
+    else:  # Linux, darwin...
         return subprocess.check_output([
             WAZUH_CONTROL_PATH, "info", "-v"
         ], stderr=subprocess.PIPE).decode('utf-8').rstrip()
@@ -114,7 +114,7 @@ def control_service(action, daemon=None, debug_mode=False):
                         continue
     else:  # Default Unix
         if daemon is None:
-            if sys.platform == MACOS or sys.platform == SOLARIS:
+            if sys.platform == MACOS:
                 result = subprocess.run(
                     [WAZUH_CONTROL_PATH, action]).returncode
             else:


### PR DESCRIPTION
# Description

This PR removes the GitHub Actions workflows for specials as these are being deprecated as Tier 3 operating systems. Issue: https://github.com/wazuh/wazuh/issues/31714
