### PR TITLE
feature: Add patterns for disabled syscollector integration tests

### DIFF
--- a/src/wazuh_testing/modules/modulesd/syscollector/patterns.py
+++ b/src/wazuh_testing/modules/modulesd/syscollector/patterns.py
@@ -48,4 +48,4 @@ CB_CHECK_CONFIG_WIN = fr'{PREFIX}DEBUG:.*"disabled":"no","scan-on-start":"yes",'
 # DataClean on collector disable patterns
 CB_ALL_DISABLED_COLLECTORS_EXIT = fr'{PREFIX}INFO: All collectors are disabled. Exiting...'
 CB_DISABLED_COLLECTORS_DETECTED = fr'{PREFIX}INFO: Disabled collectors indices with data detected: .*'
-CB_DATACLEAN_NOTIFICATION_STARTED = fr'{PREFIX}INFO: Notifying DataClean for disabled collectors indices: .*'
+CB_DATACLEAN_NOTIFICATION_STARTED = fr'{PREFIX}DEBUG: Notifying DataClean for disabled collectors indices: .*'


### PR DESCRIPTION
### Description
This PR introduces new regex patterns to the wazuh_testing framework to support integration testing for scenarios involving disabled syscollector collectors. These additions allow the testing framework to correctly identify and verify log messages related to the DataClean process and the exit of the module when all collectors are disabled.

### Proposed Changes
- Modified:
  `src/wazuh_testing/modules/modulesd/syscollector/patterns.py`:
       - Added CB_ALL_DISABLED_COLLECTORS_EXIT: Pattern to verify that module should exit when all collectors are disabled.
       - Added CB_DISABLED_COLLECTORS_DETECTED: Pattern to verify that disabled collectors with data should be detected.
       - Added CB_DATACLEAN_NOTIFICATION_STARTED: Pattern to verify that DataClean notification should be started for disabled collectors with data.

### Results and Evidence
```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-7.3.1, pluggy-1.6.0
rootdir: /home/runner/work/wazuh/wazuh/tests/integration
configfile: pytest.ini
plugins: html-3.1.1, cov-4.1.0, metadata-3.1.1
collected 39 items

test_syscollector/test_configuration/test_syscollector_configuration.py . [  2%]
......................ss..............                                   [100%]

================== 37 passed, 2 skipped in 480.28s (0:08:00) ===================
```
```
============================= test session starts =============================
platform win32 -- Python 3.11.9, pytest-7.3.1, pluggy-1.6.0
rootdir: C:\wazuh\tests\integration
configfile: pytest.ini
plugins: cov-4.1.0, html-3.1.1, metadata-3.1.1
collected 39 items

test_syscollector\test_configuration\test_syscollector_configuration.py . [  2%]
......................................                                   [100%]

============================== warnings summary ===============================
test_syscollector/test_configuration/test_syscollector_configuration.py: 39 warnings
  C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\wazuh_testing\tools\certificate_controller.py:89: DeprecationWarning: X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.
    crypto.X509Extension(b'basicConstraints', True, b'CA:TRUE, pathlen:0'),

test_syscollector/test_configuration/test_syscollector_configuration.py: 39 warnings
  C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\wazuh_testing\tools\certificate_controller.py:90: DeprecationWarning: X509Extension support in pyOpenSSL is deprecated. You should use the APIs in cryptography.
    crypto.X509Extension(b'subjectKeyIdentifier', False, b'hash', subject=cert),

test_syscollector/test_configuration/test_syscollector_configuration.py: 39 warnings
  C:\hostedtoolcache\windows\Python\3.11.9\x64\Lib\site-packages\wazuh_testing\tools\certificate_controller.py:88: DeprecationWarning: This API is deprecated and will be removed in a future version of pyOpenSSL. You should use pyca/cryptography's X.509 APIs instead.
    cert.add_extensions([

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================ 39 passed, 117 warnings in 368.38s (0:06:08) =================
```