### PR TITLE
Remove default group from remoted_simulator STARTUP response

### DIFF
--- a/src/wazuh_testing/tools/simulators/remoted_simulator.py
+++ b/src/wazuh_testing/tools/simulators/remoted_simulator.py
@@ -47,7 +47,7 @@ _DEFAULT_LIMITS_JSON = {
     },
     "cluster_name": "wazuh-cluster",
     "cluster_node": "wazuh-node-01",
-    "agent_groups": ["default"]
+    "agent_groups": []
 }
 
 


### PR DESCRIPTION
## Description

### Problem
The remoted_simulator was sending a "default" group as part of the STARTUP message response. This caused an issue in the test environment where:

1. The agent receives the "default" group assignment in the STARTUP response
2. The agent does not have the corresponding merged.mg file for the "default" group (since the test environment does not set up a merged.mg file on the agent)
3. After a few seconds, the agent-info module detects this as a group change
4. This triggers a version coordination process with other modules
5. The coordination leads to state synchronization attempts with the manager
6. Modules become blocked until the synchronization process completes

### Solution
Removed the "default" group from the remoted_simulator's STARTUP response. By not sending any group initially, we avoid triggering the group change detection mechanism when no merged.mg file is present in the test environment.

Windows:
https://github.com/wazuh/wazuh/actions/runs/21989347493/job/63532575640
https://github.com/wazuh/wazuh/actions/runs/21991612116/job/63541338186

macOS:
https://github.com/wazuh/wazuh/actions/runs/21989339264/job/63531837287
https://github.com/wazuh/wazuh/actions/runs/21991601183/job/63539958271

Linux:
https://github.com/wazuh/wazuh/actions/runs/21988336257/job/63528284511
https://github.com/wazuh/wazuh/actions/runs/21991594634/job/63539935515