### PR TITLE
Adapt qa integration framework to new agent module startup

### DIFF
--- a/src/wazuh_testing/tools/simulators/remoted_simulator.py
+++ b/src/wazuh_testing/tools/simulators/remoted_simulator.py
@@ -255,7 +255,6 @@ class RemotedSimulator(BaseSimulator):
         self.request_counter += 1
 
         if not request:
-            self.__mitm.event.set()
             return _RESPONSE_EMPTY
 
         if b'#ping' in request:
@@ -273,7 +272,6 @@ class RemotedSimulator(BaseSimulator):
         elif self.mode == 'INVALID_MSG':
             response = b'INVALID'
         elif '#!-agent shutdown' in message:
-            self.__mitm.event.set()
             response = _RESPONSE_SHUTDOWN
         elif '#!-agent startup' in message:
             # Response to HC_STARTUP with module limits JSON


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Extends the `RemotedSimulator` to support the new agent module startup gating mechanism introduced in wazuh/wazuh#34329. The simulator now sends `merged_sum` in the handshake JSON by default and can actively push `merged.mg` files to the agent, emulating production manager behavior. Also fixes a reconnection bug in the MitM handler that prevented tests performing mid-test agent restarts from working correctly.

<!--
Provide a brief description of the problem this pull request addresses. Include relevant context to help reviewers understand the purpose and scope of the changes.

If this pull request resolves an existing issue, reference it here. For example:
Closes wazuh/wazuh#34509
-->

## Proposed Changes

#### RemotedSimulator (`remoted_simulator.py`)

- Added `_DEFAULT_MERGED_MG_CONTENT` and `_DEFAULT_MERGED_SUM` constants with a minimal default merged.mg payload and its MD5 hash.
- Added `merged_sum` and `agent_groups: ["default"]` to `_DEFAULT_LIMITS_JSON` so existing tests pass the startup gate without changes.
- Exposed `DEFAULT_MERGED_MG_CONTENT` / `DEFAULT_MERGED_SUM` as class attributes for use in test fixtures.
- Added `merged_mg_content` parameter: when set, the simulator auto-computes its MD5 and injects it into `limits_config['merged_sum']`.
- Added `merged_mg_send_delay` parameter: configurable delay between handshake and file push.
- Added background thread (`_merged_mg_push_worker`) that waits for the handshake event, sleeps for the configured delay, then queues `#!-up file` protocol messages (header, 900-byte chunks, close).
- Added queue-based delivery: response callback drains one queued message per incoming agent message.
- Added `_handshake_event` set on `#!-agent startup` to coordinate the push worker with the handshake.
- Removed `self.__mitm.event.set()` from both the empty-request handler and the `#!-agent shutdown` handler. These were prematurely setting the global MitM event, which prevented the server from accepting new connections after an agent disconnect or graceful shutdown.
- Clean shutdown: `destroy()` joins the push thread.

#### MitM Handler (`mitm.py`)

- Added if not received: break in `StreamHandler.handle()` to exit the handler loop gracefully when a client disconnects (empty recv).
- Added try/except (`BrokenPipeError`, `ConnectionResetError`) around `sendall()` to handle clients disconnecting mid-response.
- Wrapped the entire custom handler loop in try/except (`ConnectionResetError`, `OSError`) to suppress noisy exceptions logged by `socketserver` when a connection is reset during `recv()`.

<!--
Summarize the changes made in this pull request. Include:
- Features added
- Bugs fixed
- Any relevant technical details
-->

### Results and Evidence

Tests results are available in the related PR:
https://github.com/wazuh/wazuh/pull/34555

<!--
Provide evidence of the changes made, such as:
- Logs
- Alerts
- Screenshots
- Before/after comparisons
-->

### Artifacts Affected

- `wazuh_testing/tools/simulators/remoted_simulator.py`
- `wazuh_testing/tools/mitm.py`

<!--
List the artifacts impacted by this pull request, such as:
- Executables (specify platforms if applicable)
- Default configuration files
- Packages
-->

## Review Checklist

<!--
- Each task must be checked to merge the PR (should also be checked if any of these do not apply, giving the corresponding feedback).
- List any manual tests completed to verify the functionality of the changes. Include any manual tests that are still required for final approval.
-->

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

<!--
Include any additional information relevant to the review process.
-->
