### PR TITLE
Rename the usage of server to manager

### DIFF
--- a/src/wazuh_testing/constants/paths/api.py
+++ b/src/wazuh_testing/constants/paths/api.py
@@ -22,4 +22,4 @@ WAZUH_API_SCRIPT = os.path.join(WAZUH_API_SCRIPTS_FOLDER_PATH, 'wazuh_manager_ap
 RBAC_DATABASE_PATH = os.path.join(WAZUH_API_SECURITY_FOLDER_PATH, 'rbac.db')
 
 # SSL paths
-WAZUH_API_CERTIFICATE = os.path.join(WAZUH_API_CONFIGURATION_FOLDER_PATH, 'ssl', 'server.crt')
+WAZUH_API_CERTIFICATE = os.path.join(WAZUH_API_CONFIGURATION_FOLDER_PATH, 'ssl', 'manager.crt')


### PR DESCRIPTION
# Summary
Update `qa-integration-framework` to be compatible with the manager renaming changes introduced in Wazuh 5.x:

- Api certificate
The `WAZUH_API_CERTIFICATE` variable has been changed from `server.crt` to `manager.crt`. This change is part of the renaming from **server** to **manager**.
