### PR TITLE
Add --set-as-main flag support to repository bumper

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -6,12 +6,19 @@ on:
     inputs:
       version:
         description: 'Target version (e.g. 1.2.3)'
-        required: true
+        default: ''
+        required: false
         type: string
       stage:
         description: 'Version stage (e.g. alpha0)'
-        required: true
+        default: ''
+        required: false
         type: string
+      set-as-main:
+        description: 'Update version values only, preserving main branch references in URLs'
+        default: false
+        required: false
+        type: boolean
       issue-link:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
@@ -65,8 +72,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          # Using workflow-specific GITHUB_TOKEN because currently CI_WAZUHCI_BUMPER_TOKEN
-          # doesn't have all the necessary permissions
           token: ${{ env.GH_TOKEN }}
 
       - name: Determine branch name
@@ -74,13 +79,16 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
           STAGE: ${{ inputs.stage }}
+          SET_AS_MAIN: ${{ inputs.set-as-main }}
         run: |
           script_params=""
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
+          set_as_main=${{ env.SET_AS_MAIN }}
 
-          # Both version and stage provided
-          script_params="${version} ${stage}"
+          [[ -n "$version" ]] && script_params+="--version $version "
+          [[ -n "$stage"   ]] && script_params+="--stage $stage "
+          [[ "$set_as_main" == "true" ]] && script_params+="--set-as-main "
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')
           BRANCH_NAME="enhancement/wqa${issue_number}-bump-${{ github.ref_name }}"
@@ -97,13 +105,21 @@ jobs:
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
       - name: Commit and push changes
+        id: commit_changes
         run: |
           git add .
+          if git diff --cached --quiet; then
+            echo "No changes detected, skipping PR creation."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           git commit -m "feat: bump ${{ github.ref_name }}"
           git push origin ${{ steps.vars.outputs.branch_name }}
+          echo "has_changes=true" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         id: create_pr
+        if: steps.commit_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -116,6 +132,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.commit_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -1,33 +1,73 @@
 #!/bin/bash
 
-# Check for the correct number of arguments
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <new_version> <stage>"
-    exit 1
-fi
+set -euo pipefail
 
-NEW_VERSION="$1"
-NEW_STAGE="$2"
+# Variables
+new_version=""
+new_stage=""
+skip_urls=""
 VERSION_FILE="VERSION.json"
 LOGFILE="tools/repository_bumper_$(date +'%Y-%m-%d_%H-%M-%S').log"
 
-# Check if version.json exists
-if [ ! -f "$VERSION_FILE" ]; then
-    echo "Version file not found!"
+usage() {
+    echo "Usage: $0 [--version <version>] [--stage <stage>] [--set-as-main]"
+    echo ""
+    echo "Options:"
+    echo "  --version <version>   Target version (e.g. 5.0.0)"
+    echo "  --stage <stage>       Version stage (e.g. alpha0)"
+    echo "  --set-as-main         Update version values only, preserving main branch references"
     exit 1
-fi
+}
 
-# Read the current version and stage from the JSON file
-CURRENT_VERSION=$(jq -r '.version' "$VERSION_FILE")
-CURRENT_STAGE=$(jq -r '.stage' "$VERSION_FILE")
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version)
+                new_version="$2"
+                shift 2
+                ;;
+            --stage)
+                new_stage="$2"
+                shift 2
+                ;;
+            --set-as-main)
+                skip_urls=true
+                shift
+                ;;
+            -h|--help)
+                usage
+                ;;
+            *)
+                echo "Unknown argument: $1"
+                usage
+                ;;
+        esac
+    done
+}
 
-echo "Current version: $CURRENT_VERSION"
-echo "Current stage: $CURRENT_STAGE"
+update_version_file() {
+    if [ ! -f "$VERSION_FILE" ]; then
+        echo "Version file not found: $VERSION_FILE"
+        exit 1
+    fi
 
-# Update the JSON file with the new version and stage
-jq --arg new_version "$NEW_VERSION" --arg new_stage "$NEW_STAGE" \
-   '.version = $new_version | .stage = $new_stage' "$VERSION_FILE" > tmp.$.json && mv tmp.$.json "$VERSION_FILE"
+    local current_version
+    local current_stage
+    current_version=$(jq -r '.version' "$VERSION_FILE")
+    current_stage=$(jq -r '.stage' "$VERSION_FILE")
 
-# Log the changes
+    local new_v="${new_version:-$current_version}"
+    local new_s="${new_stage:-$current_stage}"
+
+    jq --arg v "$new_v" --arg s "$new_s" \
+        '.version = $v | .stage = $s' "$VERSION_FILE" > tmp.$$.json && mv tmp.$$.json "$VERSION_FILE"
+
+    echo "$VERSION_FILE: version $current_version -> $new_v, stage $current_stage -> $new_s" | tee -a "$LOGFILE"
+}
+
+# ---- Main ----
+
+parse_args "$@"
+
 echo "Modified files:" | tee "$LOGFILE"
-echo "$VERSION_FILE: version $CURRENT_VERSION -> $NEW_VERSION, stage $CURRENT_STAGE -> $NEW_STAGE" | tee -a "$LOGFILE"
+update_version_file


### PR DESCRIPTION
Issue: https://github.com/wazuh/qa-integration-framework/issues/616

## Summary

- Rewrites `tools/repository_bumper.sh` to use named flags (`--version`, `--stage`, `--set-as-main`) with proper argument parsing and `set -euo pipefail`
- Adds `skip_urls` variable to gate future branch-reference replacements when `--set-as-main` is set
- Updates `.github/workflows/5_bumper_repository.yml`: adds `set-as-main` boolean input, switches script invocation to named flags, and adds no-op guard so no PR is created when the bump produces no diff