### PR TITLE
integration test flaky test analysisd tier 2

### DIFF
--- a/src/wazuh_testing/utils/services.py
+++ b/src/wazuh_testing/utils/services.py
@@ -183,7 +183,7 @@ def check_all_daemon_status():
     return daemons_status
 
 
-def wait_expected_daemon_status(target_daemon=None, running_condition=True, timeout=10, extra_sockets=[]):
+def wait_expected_daemon_status(target_daemon=None, running_condition=True, timeout=30, extra_sockets=[]):
     """Wait until Wazuh daemon's status matches the expected one. If timeout is reached and the status didn't match,
        it raises a TimeoutError.
 
@@ -191,7 +191,7 @@ def wait_expected_daemon_status(target_daemon=None, running_condition=True, time
         target_daemon (str, optional):  Wazuh daemon to check. Default `None`. None means all.
         running_condition (bool, optional): True if the daemon is expected to be running False
             if it is expected to be stopped. Default `True`.
-        timeout (int, optional): Timeout value for the check. Default `10` seconds.
+        timeout (int, optional): Timeout value for the check. Default `30` seconds.
         extra_sockets (list, optional): Additional sockets to check. They may not be present in default configuration.
 
     Raises:


### PR DESCRIPTION
# Decription

This PR resolves the issue of flaky tests in the Analysisd Tier 2 and Analysisd Tier 0 and 1 integration tests.

To address this, the timeout for the `wait_expected_daemon_status` function has been changed from 10 seconds to 30. This gives the wazuh-db module plenty of time to start up, since starting up in debug mode can take longer than 10 seconds; previously, this caused the timeout to trigger and the tests to fail.


# Tests

I spun up an environment and ran the integration tests 20 times. 
All runs passed (green). Additionally, I have been monitoring the startup time of the 
`wazuh-db` module using the `monitor.sh` script. 

During these executions, the startup time varied between 700 ms and 6,000 ms. 
Consequently, I have concluded that if a runner is heavily saturated at a specific 
moment and needs to completely wipe `wazuh-db` and then restart it in debug mode, 
it can easily hit the timeout.

- Tier 2

https://github.com/wazuh/wazuh/actions/runs/25907446192
https://github.com/wazuh/wazuh/actions/runs/25864693930
https://github.com/wazuh/wazuh/actions/runs/25860663829

- Tier 0, 1

https://github.com/wazuh/wazuh/actions/runs/26021298571
https://github.com/wazuh/wazuh/actions/runs/26021298571
https://github.com/wazuh/wazuh/actions/runs/26028539465
https://github.com/wazuh/wazuh/actions/runs/26019320263