### PR TITLE
Use _recv_exact and sendall for TCP framing

### DIFF
--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -452,6 +452,19 @@ class Agent:
 
         return headers_event
 
+    @staticmethod
+    def _recv_exact(sock, size):
+        """Receive exactly size bytes from a TCP socket."""
+        data = bytearray()
+
+        while len(data) < size:
+            chunk = sock.recv(size - len(data))
+            if not chunk:
+                return None
+            data.extend(chunk)
+
+        return bytes(data)
+
     def receive_message(self, sender):
         """Agent listener to receive messages and process the accepted commands.
         Args:
@@ -460,14 +473,14 @@ class Agent:
         while self.stop_receive == 0:
             if is_tcp(sender.protocol):
                 try:
-                    rcv = sender.socket.recv(4)
-                    if len(rcv) == 4:
-                        data_len = secure_message.unpack(rcv)
-                        buffer_array = sender.socket.recv(data_len)
-                        if data_len != len(buffer_array):
-                            continue
-                    else:
-                        continue
+                    rcv = self._recv_exact(sender.socket, 4)
+                    if rcv is None:
+                        return
+
+                    data_len = secure_message.unpack(rcv)
+                    buffer_array = self._recv_exact(sender.socket, data_len)
+                    if buffer_array is None:
+                        return
                 except MemoryError:
                     logging.critical(f"Memory error, trying to allocate {data_len}.")
                     return
@@ -1493,6 +1506,7 @@ class Sender:
         manager_address (str): IP of the manager.
         manager_port (str, optional): port used by remoted in the manager.
         protocol (str, optional): protocol used by remoted. TCP or UDP.
+        socket_timeout (int, optional): timeout in seconds for TCP socket operations.
         socket (socket): sock_stream used to connect with remoted.
     Examples:
         To create a Sender, you need to create an agent first, and then, create the sender. Finally, to send messages
@@ -1502,10 +1516,11 @@ class Sender:
         >>> agent = ag.Agent(manager_address, "aes", os="debian8", version="4.2.0")
         >>> sender = ag.Sender(manager_address, protocol=TCP)
     """
-    def __init__(self, manager_address, manager_port='1514', protocol=TCP):
+    def __init__(self, manager_address, manager_port='1514', protocol=TCP, socket_timeout=30):
         self.manager_address = manager_address
         self.manager_port = manager_port
         self.protocol = protocol.upper()
+        self.socket_timeout = socket_timeout
         self.socket = None
         self.connect()
 
@@ -1513,6 +1528,7 @@ class Sender:
         if is_tcp(self.protocol):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.connect((self.manager_address, int(self.manager_port)))
+            self.socket.settimeout(self.socket_timeout)
         if is_udp(self.protocol):
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
@@ -1527,16 +1543,16 @@ class Sender:
     def send_event(self, event):
         if is_tcp(self.protocol):
             length = pack('<I', len(event))
+            payload = length + event
             try:
                 if self.socket.fileno() != -1:
-                    self.socket.send(length + event)
+                    self.socket.sendall(payload)
             except BrokenPipeError:
                 logging.warning(f"Broken Pipe error while sending event. Creating new socket...")
                 sleep(5)
-                self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                self.connect()
                 if self.socket.fileno() != -1 and is_valid_fd(self.socket.fileno()):
-                    self.socket.connect((self.manager_address, int(self.manager_port)))
-                    self.socket.send(length + event)
+                    self.socket.sendall(payload)
             except ConnectionResetError:
                 logging.warning(f"Connection reset by peer. Continuing...")
 


### PR DESCRIPTION
## Description

This PR fixes a flaky TCP behavior in the agent simulator used by integration tests.

The simulator was assuming that a single `socket.recv(data_len)` call always returns the full framed payload announced by the 4-byte TCP header. TCP does not guarantee that: under load, a payload can be split across multiple reads. When that happened, the simulator discarded the partial payload and continued reading, leaving the remaining bytes in the socket buffer. The next `recv(4)` could then read payload bytes as if they were a new frame header, desynchronizing the stream.

This was observed in `test_shared_configuration[test shared configuration0]`, where `wazuh-remoted` finished sending `merged.mg`, but the simulated agent never queued the final `#!-close file` message.

## Changes

- Added `_recv_exact(sock, size)` to read exactly the expected number of bytes from TCP sockets.
- Updated `Agent.receive_message()` to read both the 4-byte frame header and the payload using `_recv_exact()`.
- Replaced TCP `send()` with `sendall()` in `Sender.send_event()` to avoid partial sends from the simulator.

## Validation

- Reproduced the original failure under load with the unpatched simulator.
- Confirmed manager logs showed `Sending file 'default/merged.mg'` and `End sending file 'default/merged.mg'`, while the simulator queue missed `#!-close file`.
- Re-ran `test_shared_configuration[test shared configuration0]` under load after the fix.
- Verified the simulator now receives complete TCP frames without losing the final shared configuration marker.
