### PR TITLE
Bump version to 4.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.10.5]
+
 ## [4.10.4]
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_install_requires() -> List[str]:
 
 setup(
     name='wazuh_testing',
-    version='4.10.4',
+    version='4.10.5',
     description='Wazuh testing utilities to help programmers automate tests',
     url='https://github.com/wazuh',
     author='Wazuh',


### PR DESCRIPTION
## Description

Bump the `4.10.5` branch from `4.10.4` to `4.10.5`, including an empty `[4.10.5]` section in `CHANGELOG.md` ready to receive entries.

Closes #701.
