### PR TITLE
Update SCA log patterns after agent log review (wazuh#36234)

### DIFF
--- a/src/wazuh_testing/modules/modulesd/sca/patterns.py
+++ b/src/wazuh_testing/modules/modulesd/sca/patterns.py
@@ -4,10 +4,10 @@
 from . import PREFIX
 
 # Callback Messages
-SCA_ENABLED = fr"{PREFIX}DEBUG: SCA module enabled"
-SCA_DISABLED = fr"{PREFIX}DEBUG: SCA module disabled\. Exiting"
-SCA_STARTING = fr"{PREFIX}DEBUG: Starting SCA module"
-SCA_RUNNING = fr"{PREFIX}INFO: SCA module running"
+SCA_ENABLED = fr"{PREFIX}DEBUG: Module enabled"
+SCA_DISABLED = fr"{PREFIX}DEBUG: Module disabled\. Exiting"
+SCA_STARTING = fr"{PREFIX}DEBUG: Starting module"
+SCA_RUNNING = fr"{PREFIX}DEBUG: SCA module running"
 SCA_SCAN_STARTED_REQ = fr"{PREFIX}DEBUG: Starting Policy requirements evaluation for policy \"(.*?)\""
 SCA_SCAN_ENDED_REQ = fr"{PREFIX}DEBUG: Policy requirements evaluation completed for policy \"(.*?)\", result: (Passed|Failed)"
 SCA_SCAN_STARTED_CHECK = fr"{PREFIX}DEBUG: Starting Policy checks evaluation for policy \"(.*?)\""

--- a/src/wazuh_testing/modules/modulesd/syscollector/patterns.py
+++ b/src/wazuh_testing/modules/modulesd/syscollector/patterns.py
@@ -6,11 +6,11 @@ from . import WMODULES_PREFIX
 
 
 # Callback messages
-CB_MODULE_STARTING = fr'{PREFIX}DEBUG: Starting Syscollector.'
-CB_MODULE_STARTED = fr'{PREFIX}INFO: Module started.'
+CB_MODULE_STARTING = fr'{PREFIX}DEBUG: Starting module.'
+CB_MODULE_STARTED = fr'{PREFIX}INFO: Started \(pid: \d+\).'
 CB_SCAN_STARTED = fr'{PREFIX}INFO: Starting evaluation.'
 CB_SCAN_FINISHED = fr'{PREFIX}INFO: Evaluation finished.'
-CB_SYSCOLLECTOR_DISABLED = fr'{PREFIX}INFO: Module disabled. Exiting...'
+CB_SYSCOLLECTOR_DISABLED = fr'{PREFIX}INFO: Module disabled. Exiting.'
 CB_HARDWARE_SCAN_STARTED = fr'{PREFIX}DEBUG: Starting hardware scan'
 CB_HARDWARE_SCAN_FINISHED = fr'{PREFIX}DEBUG: Ending hardware scan'
 CB_OS_SCAN_STARTED = fr'{PREFIX}DEBUG: Starting os scan'


### PR DESCRIPTION
## Description

Align the SCA module test patterns with the new log messages and levels introduced in [wazuh/wazuh#36234](https://github.com/wazuh/wazuh/pull/36234), which restored several agent INFO logs and standardized module wording. With the old patterns the integration fixture `wait_for_sca_enabled` times out because the strings no longer match.

