### PR TITLE
Update changelog for 4.14.6 RC 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.14.6]
+
+### Changed
+
+- Migrated certificate generation to the `cryptography` API for `pyOpenSSL` 26.x compatibility. ([#685](https://github.com/wazuh/qa-integration-framework/pull/685))
+
+### Fixed
+
+- Fixed TCP framing in `agent_simulator` by reading complete frames and using `sendall` to prevent partial sends. ([#691](https://github.com/wazuh/qa-integration-framework/pull/691))
+- Extended `wazuh-db` startup timeout in `wait_expected_daemon_status` to reduce flakiness in analysisd integration tests. ([#686](https://github.com/wazuh/qa-integration-framework/pull/686))
+
 ## [4.14.1]
 
 ## [4.14.0]


### PR DESCRIPTION
## Description

Add the `[4.14.6]` section to `CHANGELOG.md` capturing the user-facing PRs merged into the `4.14.6` branch since `v4.14.5` before cutting RC 1.

Related to #710.

## Proposed Changes

New section `[4.14.6]` with:

### Changed
- `cryptography` API migration for `pyOpenSSL` 26.x compatibility ([#685](https://github.com/wazuh/qa-integration-framework/pull/685))

### Fixed
- `agent_simulator` TCP framing (`_recv_exact` / `sendall`) ([#691](https://github.com/wazuh/qa-integration-framework/pull/691))
- `wazuh-db` startup timeout extension in analysisd IT ([#686](https://github.com/wazuh/qa-integration-framework/pull/686))

## Tests Introduced

None — documentation only.