### PR TITLE
Adapt code for remoted IT

### DIFF
--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -17,6 +17,7 @@ DIFF_PATH_FILE = os.path.join(QUEUE_DIFF_PATH, 'file')
 
 ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
 ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
+ANALYSISD_ENRICH_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue-http.sock')
 AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
@@ -29,7 +30,7 @@ MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor')
 REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote')
 SYSCHECKD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'syscheck')
 WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_DB_PATH, 'wdb')
-ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_ALERTS_PATH, 'ar')
+ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'ar')
 
 
 WAZUH_SOCKETS = {
@@ -37,7 +38,7 @@ WAZUH_SOCKETS = {
     'wazuh-manager-apid': [],
     'wazuh-manager-analysisd': [
         ANALYSISD_ANALISIS_SOCKET_PATH,
-        ANALYSISD_QUEUE_SOCKET_PATH
+        ANALYSISD_ENRICH_SOCKET_PATH,
     ],
     'wazuh-manager-authd': [AUTHD_SOCKET_PATH],
     'wazuh-execd': [EXECD_SOCKET_PATH],

--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -17,7 +17,6 @@ DIFF_PATH_FILE = os.path.join(QUEUE_DIFF_PATH, 'file')
 
 ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
 ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
-ANALYSISD_ENRICH_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue-http.sock')
 AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
@@ -38,7 +37,6 @@ WAZUH_SOCKETS = {
     'wazuh-manager-apid': [],
     'wazuh-manager-analysisd': [
         ANALYSISD_ANALISIS_SOCKET_PATH,
-        ANALYSISD_ENRICH_SOCKET_PATH,
     ],
     'wazuh-manager-authd': [AUTHD_SOCKET_PATH],
     'wazuh-execd': [EXECD_SOCKET_PATH],

--- a/src/wazuh_testing/modules/api/utils.py
+++ b/src/wazuh_testing/modules/api/utils.py
@@ -325,10 +325,11 @@ def compare_config_api_response(configuration, section):
 
 
 def get_manager_configuration(section=None, field=None):
-    """Get Wazuh manager configuration response from API using GET /manager/configuration
+    """Get Wazuh manager configuration response from API using GET /cluster/{node_id}/configuration.
 
-    References: https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/
-                api.controllers.manager_controller.get_configuration
+    In 5.x the legacy /manager/configuration endpoint was removed; the equivalent is
+    /cluster/{node_id}/configuration. Standalone managers are treated as a single-node cluster,
+    so the local node name is resolved first via /cluster/local/info.
 
     Args:
         section (str): wazuh configuration section, E.g: "active-response", "ruleset"...
@@ -340,17 +341,25 @@ def get_manager_configuration(section=None, field=None):
          as keys.
     """
     api_details = get_api_details_dict()
-    api_query = f"{api_details['base_url']}/manager/configuration?"
 
+    node_info_response = requests.get(f"{api_details['base_url']}/cluster/local/info",
+                                      headers=api_details['auth_headers'], verify=False)
+    node_info_response.raise_for_status()
+    node_info_items = node_info_response.json().get('data', {}).get('affected_items', [])
+    assert node_info_items, f"Could not resolve local node from /cluster/local/info: {node_info_response.json()}"
+    node_name = node_info_items[0]['node']
+
+    api_query = f"{api_details['base_url']}/cluster/{node_name}/configuration?"
     if section is not None:
         api_query += f"section={section}"
         if field is not None:
             api_query += f"&field={field}"
 
     response = requests.get(api_query, headers=api_details['auth_headers'], verify=False)
-
-    assert response.json()['error'] == 0, f"Wazuh API response status different from 0: {response.json()}"
-    answer = response.json()['data']['affected_items'][0]
+    response.raise_for_status()
+    affected_items = response.json().get('data', {}).get('affected_items', [])
+    assert affected_items, f"Empty configuration response from {api_query}: {response.json()}"
+    answer = affected_items[0]
 
     def get_requested_values(answer, section, field):
         """Return requested value from API response

--- a/src/wazuh_testing/modules/api/utils.py
+++ b/src/wazuh_testing/modules/api/utils.py
@@ -325,7 +325,10 @@ def compare_config_api_response(configuration, section):
 
 
 def get_manager_configuration(section=None, field=None):
-    """Get Wazuh manager configuration response from API using GET /cluster/{node_id}/configuration
+    """Get Wazuh manager configuration response from API using GET /manager/configuration
+
+    References: https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/
+                api.controllers.manager_controller.get_configuration
 
     Args:
         section (str): wazuh configuration section, E.g: "active-response", "ruleset"...
@@ -337,17 +340,8 @@ def get_manager_configuration(section=None, field=None):
          as keys.
     """
     api_details = get_api_details_dict()
+    api_query = f"{api_details['base_url']}/manager/configuration?"
 
-    node_info_response = requests.get(
-        f"{api_details['base_url']}/cluster/local/info",
-        headers=api_details['auth_headers'],
-        verify=False
-    )
-    assert node_info_response.json()['error'] == 0, \
-        f"Could not get local node info: {node_info_response.json()}"
-    node_name = node_info_response.json()['data']['affected_items'][0]['node']
-
-    api_query = f"{api_details['base_url']}/cluster/{node_name}/configuration?"
     if section is not None:
         api_query += f"section={section}"
         if field is not None:

--- a/src/wazuh_testing/modules/api/utils.py
+++ b/src/wazuh_testing/modules/api/utils.py
@@ -325,10 +325,7 @@ def compare_config_api_response(configuration, section):
 
 
 def get_manager_configuration(section=None, field=None):
-    """Get Wazuh manager configuration response from API using GET /manager/configuration
-
-    References: https://documentation.wazuh.com/current/user-manual/api/reference.html#operation/
-                api.controllers.manager_controller.get_configuration
+    """Get Wazuh manager configuration response from API using GET /cluster/{node_id}/configuration
 
     Args:
         section (str): wazuh configuration section, E.g: "active-response", "ruleset"...
@@ -340,8 +337,17 @@ def get_manager_configuration(section=None, field=None):
          as keys.
     """
     api_details = get_api_details_dict()
-    api_query = f"{api_details['base_url']}/manager/configuration?"
 
+    node_info_response = requests.get(
+        f"{api_details['base_url']}/cluster/local/info",
+        headers=api_details['auth_headers'],
+        verify=False
+    )
+    assert node_info_response.json()['error'] == 0, \
+        f"Could not get local node info: {node_info_response.json()}"
+    node_name = node_info_response.json()['data']['affected_items'][0]['node']
+
+    api_query = f"{api_details['base_url']}/cluster/{node_name}/configuration?"
     if section is not None:
         api_query += f"section={section}"
         if field is not None:

--- a/src/wazuh_testing/modules/remoted/patterns.py
+++ b/src/wazuh_testing/modules/remoted/patterns.py
@@ -6,6 +6,7 @@
 from . import PREFIX
 
 INVALID_VALUE_FOR_ELEMENT = fr"{PREFIX}.*Invalid value for element.*"
+INVALID_ELEMENT_IN_CONFIGURATION = fr"{PREFIX}.*Invalid element in the configuration.*"
 CONFIGURATION_ERROR = r".*{severity}:.*Configuration error at '{path}'.*"
 
 INVALID_VALUE_FOR_PORT_NUMBER = fr"{PREFIX}.*Invalid port number.*"

--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -1763,7 +1763,7 @@ class InjectorThread(threading.Thread):
 
 
 def create_agents(agents_number, manager_address, cypher='aes', fim_eps=100, authd_password=None, agents_os=None,
-                  agents_version=None, disable_all_modules=False):
+                  agents_version=None, disable_all_modules=False, retry_enrollment=False):
     """Create a list of generic agents
     This will create a list with `agents_number` amount of agents. All of them will be registered in the same manager.
     Args:
@@ -1775,6 +1775,7 @@ def create_agents(agents_number, manager_address, cypher='aes', fim_eps=100, aut
         agents_os (list, optional): list containing different operative systems for the agents.
         agents_version (list, optional): list containing different version of the agent.
         disable_all_modules (boolean): Disable all simulated modules for this agent.
+        retry_enrollment (bool, optional): Retry enrollment if authd is not yet ready. Default False.
     Returns:
         list: list of the new virtual agents.
     """
@@ -1786,7 +1787,8 @@ def create_agents(agents_number, manager_address, cypher='aes', fim_eps=100, aut
         agent_version = agents_version[agent] if agents_version is not None else None
 
         agents.append(Agent(manager_address, cypher, fim_eps=fim_eps, authd_password=authd_password,
-                            os=agent_os, version=agent_version, disable_all_modules=disable_all_modules))
+                            os=agent_os, version=agent_version, disable_all_modules=disable_all_modules,
+                            retry_enrollment=retry_enrollment))
 
         agent_count = agent_count + 1
 


### PR DESCRIPTION
# Description

This PR updates several constants and utilities in the QA integration framework to align with recent changes in Wazuh's internal architecture. The main areas of change are configuration path constants, socket path constants, the analysisd socket list, and the API utility used to fetch manager configuration.

## Proposed changes

- **`constants/paths/configurations.py`**: Updated `WAZUH_LOCAL_INTERNAL_OPTIONS` to conditionally resolve to `wazuh-manager-internal-options.conf` when running in manager mode, or `local_internal_options.conf` otherwise, mirroring the existing behaviour of `WAZUH_CONF_PATH`.

- **`constants/paths/sockets.py`**:
  - Added new constant `ANALYSISD_ENRICH_SOCKET_PATH` pointing to the `queue-http.sock` socket, which replaces `ANALYSISD_QUEUE_SOCKET_PATH` in the `wazuh-manager-analysisd` socket list.
  - Fixed `ACTIVE_RESPONSE_SOCKET_PATH` to use `QUEUE_SOCKETS_PATH` instead of the incorrect `QUEUE_ALERTS_PATH`.

- **`modules/api/utils.py`**: Updated `get_manager_configuration()` to use the cluster-aware endpoint `/cluster/{node_id}/configuration` instead of the generic `/manager/configuration`. The function now first queries `/cluster/local/info` to resolve the local node name and builds the request URL dynamically.

- **`modules/remoted/patterns.py`**: Added a new log pattern constant `INVALID_ELEMENT_IN_CONFIGURATION` to match log messages containing *"Invalid element in the configuration"*.