### PR TITLE
Merge merge-4.14.6-into-4.14.7 into 4.14.7 [automated]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.14.6]
+
+### Changed
+
+- Migrated certificate generation to the `cryptography` API for `pyOpenSSL` 26.x compatibility. ([#685](https://github.com/wazuh/qa-integration-framework/pull/685))
+
+### Fixed
+
+- Fixed TCP framing in `agent_simulator` by reading complete frames and using `sendall` to prevent partial sends. ([#691](https://github.com/wazuh/qa-integration-framework/pull/691))
+- Extended `wazuh-db` startup timeout in `wait_expected_daemon_status` to reduce flakiness in analysisd integration tests. ([#686](https://github.com/wazuh/qa-integration-framework/pull/686))
+
 ## [4.14.1]
 
 ## [4.14.0]

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.14.6",
-  "stage": "alpha0"
+  "stage": "rc1"
 }

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.14.6",
-  "stage": "alpha0"
+  "version": "4.14.16",
+  "stage": "rc1"
 }

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.14.16",
-  "stage": "rc1"
+  "version": "4.14.6",
+  "stage": "alpha0"
 }


### PR DESCRIPTION
Automated upward merge created by the branch maintenance process.

## Conflicts resolved

Single conflict, version-bump related (4.14.6 RC1 vs 4.14.7 alpha0):

- **Kept 4.14.7-alpha0** (`--ours`): `VERSION.json`.

`CHANGELOG.md` auto-merged cleanly (4.14.6 RC1 entries added).