### PR TITLE
Update remoted statistics schemas

### DIFF
--- a/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-manager-remoted_template.json
+++ b/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-manager-remoted_template.json
@@ -65,14 +65,22 @@
                                           "startup"
                                         ]
                                       },
-                                      "event": {
+                                      "events": {
+                                        "type": "integer"
+                                      },
+                                      "states": {
+                                        "type": "integer"
+                                      },
+                                      "upgrade_ack": {
                                         "type": "integer"
                                       }
                                     },
                                     "required": [
                                       "control",
                                       "control_breakdown",
-                                      "event"
+                                      "events",
+                                      "states",
+                                      "upgrade_ack"
                                     ]
                                   },
                                   "sent_breakdown": {

--- a/src/wazuh_testing/data/statistics_template/cluster_statistics_format_test_module/wazuh-manager-remoted_template.json
+++ b/src/wazuh_testing/data/statistics_template/cluster_statistics_format_test_module/wazuh-manager-remoted_template.json
@@ -80,13 +80,22 @@
                               "discarded": {
                                 "type": "integer"
                               },
-                              "event": {
+                              "events_failed": {
+                                "type": "integer"
+                              },
+                              "events": {
                                 "type": "integer"
                               },
                               "ping": {
                                 "type": "integer"
                               },
+                              "states": {
+                                "type": "integer"
+                              },
                               "unknown": {
+                                "type": "integer"
+                              },
+                              "upgrade_ack": {
                                 "type": "integer"
                               }
                             },
@@ -95,9 +104,12 @@
                               "control_breakdown",
                               "dequeued_after",
                               "discarded",
-                              "event",
+                              "events_failed",
+                              "events",
                               "ping",
-                              "unknown"
+                              "states",
+                              "unknown",
+                              "upgrade_ack"
                             ]
                           },
                           "sent_breakdown": {


### PR DESCRIPTION
## Summary

Updates the remoted statistics JSON schemas used by API integration tests to match the counters introduced in wazuh/wazuh#36456.

## Changes

- Replaces the old `event` required field with `events` in remoted received breakdown schemas.
- Adds the new global remoted counters `events_failed`, `states`, and `upgrade_ack` to the cluster statistics schema.
- Adds the new per-agent remoted counters `states` and `upgrade_ack` to the agent statistics schema.

## Evidences

https://github.com/wazuh/wazuh/actions/runs/26639243908/job/78507518486