### PR TITLE
Drop wodles from python coverage modules

### DIFF
--- a/src/wazuh_testing/scripts/pytest_coverage.py
+++ b/src/wazuh_testing/scripts/pytest_coverage.py
@@ -7,7 +7,6 @@ from os.path import basename, exists, join, dirname
 PYTHON_MODULES = (
     'framework',  # Framework
     'api/api',  # API
-    'wodles',  # External modules
 )
 
 COVERAGE_FILE = '.coverage'


### PR DESCRIPTION
In parallel with  issue: [#36150](https://github.com/wazuh/wazuh/issues/36150) and as part of [Optimize and simplify Wazuh 5.x PR workflows #36746](https://github.com/wazuh/wazuh/issues/36746)

- wodles unit tests and coverage now run in wazuh's 5_testunit_wodles.yml
- avoids duplicate execution in python coverage runs