### PR TITLE
Auto-read authd.pass when use_password is enabled by default

### DIFF
--- a/src/wazuh_testing/tools/simulators/agent_simulator.py
+++ b/src/wazuh_testing/tools/simulators/agent_simulator.py
@@ -28,6 +28,7 @@ from time import mktime, localtime, sleep, time
 from typing import Tuple
 
 from wazuh_testing import DATA_PATH
+from wazuh_testing.constants.paths.configurations import DEFAULT_AUTHD_PASS_PATH
 from wazuh_testing.utils import secure_message
 from wazuh_testing.utils.db_queries import global_db
 from wazuh_testing.utils.decorators import retry
@@ -380,10 +381,20 @@ class Agent:
             ssl_socket = context.wrap_socket(sock, server_hostname=self.registration_address)
             ssl_socket.connect((self.registration_address, 1515))
 
-            if self.authd_password is None:
+            password = self.authd_password
+            if password is None:
+                # use_password=yes is the default since wazuh/wazuh#37151; auto-read the
+                # manager-generated password file so tests don't need to pass it explicitly.
+                try:
+                    with open(DEFAULT_AUTHD_PASS_PATH) as _f:
+                        password = _f.read().strip() or None
+                except OSError:
+                    pass
+
+            if password is None:
                 event = f"OSSEC A:'{self.name}'\n".encode()
             else:
-                event = f"OSSEC PASS: {self.authd_password} OSSEC A:'{self.name}'\n".encode()
+                event = f"OSSEC PASS: {password} OSSEC A:'{self.name}'\n".encode()
 
             ssl_socket.send(event)
             recv = ssl_socket.recv(4096)


### PR DESCRIPTION
## Summary

- `_register_helper()` in `agent_simulator.py` now auto-reads `DEFAULT_AUTHD_PASS_PATH` (`/var/wazuh-manager/etc/authd.pass`) when `authd_password=None`.
- Fixes agent enrollment failures in integration tests after wazuh/wazuh#37151 changed `<use_password>` to `yes` by default — the manager now rejects passwordless enrollment requests, causing `ValueError: The agent X was not correctly enrolled.` in test setup.
- Falls back to the original passwordless enrollment if the file doesn't exist, so tests against managers with `use_password=no` are unaffected.

## Related

- wazuh/wazuh#37151 — introduced `use_password=yes` as default