### PR TITLE
Enable use_password in minimal config to match agent simulator default

### DIFF
--- a/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.conf
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.conf
@@ -46,7 +46,7 @@
     <port>1515</port>
     <use_source_ip>no</use_source_ip>
     <purge>yes</purge>
-    <use_password>no</use_password>
+    <use_password>yes</use_password>
     <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>


### PR DESCRIPTION
## Summary

- After wazuh/wazuh#37151 (`bb4cae9316`), authd generates `authd.pass` on startup when `use_password=yes`, and the agent simulator (#759) now auto-reads that file
- `all_disabled_wazuh.conf` still had `<use_password>no</use_password>`, causing a mismatch: the agent sends `OSSEC PASS: ... OSSEC A:'name'` but authd (with `use_password=no`) skips the password block without advancing `buf`, so `strncmp` for `OSSEC A:'` fails against the `OSSEC PASS:` prefix → `"ERROR: Invalid request for new agent"` → `test_agent_statistics_format` fails with `IndexError`
- Fix: set `<use_password>yes</use_password>` so authd reads/generates `authd.pass` on restart; both sides now agree on the password
