### PR TITLE
Skip bump commit and PR when no changes are needed

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -124,10 +124,17 @@ jobs:
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
       - name: Commit changes (Bump)
+        id: bump_step
         if: inputs.revert != true
         run: |
           git add .
-          git commit -m "feat: bump ${{ github.ref_name }}"
+          if git diff --staged --quiet; then
+            echo "No changes to commit. Skipping."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "feat: bump ${{ github.ref_name }}"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Revert references (Revert)
         id: revert_step
@@ -171,13 +178,13 @@ jobs:
           fi
 
       - name: Push changes
-        if: inputs.revert != true || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.bump_step.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           git push origin ${{ steps.vars.outputs.branch_name }}
 
       - name: Create pull request
         id: create_pr
-        if: inputs.revert != true || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.bump_step.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -190,7 +197,7 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
-        if: inputs.revert != true || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
+        if: (inputs.revert != true && steps.bump_step.outputs.has_changes == 'true') || (inputs.revert == true && steps.revert_step.outputs.has_changes == 'true')
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin


### PR DESCRIPTION
# Description

Issue related: https://github.com/wazuh/qa-integration-framework/issues/765

When the bump script produces no file changes, `git commit` was failing with exit code 1 because the working tree was already clean.

The fix mirrors the pattern already used in the revert path:
- Check `git diff --staged --quiet` after staging
- If no changes: emit `has_changes=false` and skip the commit
- Push, create PR, and merge steps now gate on `has_changes == 'true'` for both bump and revert paths

## Test

Triggered the workflow on branch `test/765-bumper-no-changes` (which has this fix) with `version=5.0.1 stage=alpha0` the same values already present in `VERSION.json`, so the bumper produces no changes.

Result: https://github.com/wazuh/qa-integration-framework/actions/runs/28608830286

- `Commit changes (Bump)` → passed, skipped commit
- `Push changes` / `Create pull request` / `Merge pull request` → skipped
- Workflow exits green