### PR TITLE
Update changelog for 4.14.7 and fix changelog-enforcer skip label

### DIFF
--- a/.github/workflows/4_codequality_changelog.yml
+++ b/.github/workflows/4_codequality_changelog.yml
@@ -24,5 +24,5 @@ jobs:
         uses: dangoslen/changelog-enforcer@v3
         id: verify-changelog
         with:
-          skipLabels: "autocut,skip-changelog"
+          skipLabels: "autocut,no-changelog"
           changeLogPath: "CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.14.7]
+
+### Changed
+
+- Replaced deprecated `pyOpenSSL` functions in `CertificateController` and `AuthdSimulator` with the `cryptography` API. ([#748](https://github.com/wazuh/qa-integration-framework/pull/748))
+
+### Fixed
+
+- Fixed `authd` flaky tests by running the `ManInTheMiddle` listener thread as a daemon thread. ([#707](https://github.com/wazuh/qa-integration-framework/pull/707))
+
 ## [4.14.6]
 
 ### Changed


### PR DESCRIPTION
## Description

Adds the missing changelog entries for the `4.14.7` release and corrects the label used by the changelog-enforcer workflow to skip its check. The `4.14.7` section existed but was empty; this fills it in with the changes that were merged into the branch, following the same format used for previous releases. It also aligns the workflow's `skipLabels` setting with the label actually used in this repository.

## Proposed Changes

- Added a **Changed** entry documenting the replacement of deprecated `pyOpenSSL` functions in `CertificateController` and `AuthdSimulator` with the `cryptography` API, referencing [#748](https://github.com/wazuh/qa-integration-framework/pull/748).
- Added a **Fixed** entry documenting the `authd` flaky tests fix (running the `ManInTheMiddle` listener thread as a daemon thread), referencing [#707](https://github.com/wazuh/qa-integration-framework/pull/707).
- Fixed the changelog-enforcer workflow (`4_codequality_changelog.yml`) so that the exclusion label is `no-changelog` instead of `skip-changelog`.

### Results and Evidence

N/A — documentation and workflow configuration change.

### Artifacts Affected

N/A — no build or release artifacts are affected.

### Configuration Changes

Updated `skipLabels` in `.github/workflows/4_codequality_changelog.yml` from `"autocut,skip-changelog"` to `"autocut,no-changelog"`, so PRs labeled `no-changelog` correctly bypass the changelog check.

### Documentation Updates

`CHANGELOG.md` updated under the `[4.14.7]` section.

### Tests Introduced

N/A — no code changes.

## Review Checklist

- [x] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [x] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
