### PR TITLE
Add changelog entry for the analysisd statistics template update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Updated states persistence patterns and fixes. ([#465](https://github.com/wazuh/qa-integration-framework/pull/465))
 - Demoted SCA and logcollector tests. ([#612](https://github.com/wazuh/qa-integration-framework/pull/612))
 - Support manager naming changes. ([#592](https://github.com/wazuh/qa-integration-framework/pull/592))
+- Updated the analysisd statistics template to the engine metrics dump format. ([#783](https://github.com/wazuh/qa-integration-framework/pull/783))
 
 ### Removed
 


### PR DESCRIPTION
## Description

Changelog review for the 5.0.0 Beta 4 stage. One PR merged into `5.0.0` since the Beta 3 review (#764) lacks a changelog entry and does not carry the `no-changelog` label: #783, which updated the analysisd statistics template to the engine metrics dump format after the fix for wazuh/wazuh#37521.

The other PRs merged in the same window need no entry: #772 carries `no-changelog` and the `cryptography` migration it ports is already covered by the #683 entry, and #775 only updates SECURITY.md.

Closes #785.

## Proposed Changes

- Add a Changed entry to the `[v5.0.0]` section for PR #783.

### Results and Evidence

```diff
 - Support manager naming changes. ([#592](https://github.com/wazuh/qa-integration-framework/pull/592))
+- Updated the analysisd statistics template to the engine metrics dump format. ([#783](https://github.com/wazuh/qa-integration-framework/pull/783))
```

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

None.

### Tests Introduced

None.

## Review Checklist
- [x] Code changes reviewed
- [x] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
- [x] PR is linked to the relevant issue(s)
- [x] Correct labels applied (e.g., `no-changelog`)
