### PR TITLE
Update agent analysisd statistics template to the engine metrics dump format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Demoted SCA and logcollector tests. ([#612](https://github.com/wazuh/qa-integration-framework/pull/612))
 - Support manager naming changes. ([#592](https://github.com/wazuh/qa-integration-framework/pull/592))
 - Updated the analysisd statistics template to the engine metrics dump format. ([#783](https://github.com/wazuh/qa-integration-framework/pull/783))
+- Updated the agent analysisd statistics template to the engine metrics dump format. ([#790](https://github.com/wazuh/qa-integration-framework/pull/790))
 
 ### Removed
 

--- a/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-manager-analysisd_template.json
+++ b/src/wazuh_testing/data/statistics_template/agent_statistics_format_test_module/wazuh-manager-analysisd_template.json
@@ -11,194 +11,55 @@
               {
                 "type": "object",
                 "properties": {
-                  "timestamp": {
-                    "type": "string"
-                  },
                   "name": {
                     "type": "string",
                     "pattern": "^wazuh-manager-analysisd$"
                   },
-                  "agents": {
+                  "uptime": {
+                    "type": "string"
+                  },
+                  "timestamp": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "global": {
                     "type": "array",
-                    "items": [
-                      {
-                        "type": "object",
-                        "properties": {
-                          "uptime": {
-                            "type": "string"
-                          },
-                          "id": {
-                            "type": "integer"
-                          },
-                          "metrics": {
-                            "type": "object",
-                            "properties": {
-                              "events": {
-                                "type": "object",
-                                "properties": {
-                                  "processed": {
-                                    "type": "integer"
-                                  },
-                                  "received_breakdown": {
-                                    "type": "object",
-                                    "properties": {
-                                      "decoded_breakdown": {
-                                        "type": "object",
-                                        "properties": {
-                                          "agent": {
-                                            "type": "integer"
-                                          },
-                                          "dbsync": {
-                                            "type": "integer"
-                                          },
-                                          "modules_breakdown": {
-                                            "type": "object",
-                                            "properties": {
-                                              "aws": {
-                                                "type": "integer"
-                                              },
-                                              "azure": {
-                                                "type": "integer"
-                                              },
-                                              "command": {
-                                                "type": "integer"
-                                              },
-                                              "docker": {
-                                                "type": "integer"
-                                              },
-                                              "gcp": {
-                                                "type": "integer"
-                                              },
-                                              "github": {
-                                                "type": "integer"
-                                              },
-                                              "logcollector_breakdown": {
-                                                "type": "object",
-                                                "properties": {
-                                                  "eventchannel": {
-                                                    "type": "integer"
-                                                  },
-                                                  "eventlog": {
-                                                    "type": "integer"
-                                                  },
-                                                  "macos": {
-                                                    "type": "integer"
-                                                  },
-                                                  "others": {
-                                                    "type": "integer"
-                                                  }
-                                                },
-                                                "required": [
-                                                  "eventchannel",
-                                                  "eventlog",
-                                                  "macos",
-                                                  "others"
-                                                ]
-                                              },
-                                              "office365": {
-                                                "type": "integer"
-                                              },
-                                              "rootcheck": {
-                                                "type": "integer"
-                                              },
-                                              "sca": {
-                                                "type": "integer"
-                                              },
-                                              "syscheck": {
-                                                "type": "integer"
-                                              },
-                                              "syscollector": {
-                                                "type": "integer"
-                                              },
-                                              "upgrade": {
-                                                "type": "integer"
-                                              },
-                                              "vulnerability": {
-                                                "type": "integer"
-                                              }
-                                            },
-                                            "required": [
-                                              "aws",
-                                              "azure",
-                                              "command",
-                                              "docker",
-                                              "gcp",
-                                              "github",
-                                              "logcollector_breakdown",
-                                              "office365",
-                                              "rootcheck",
-                                              "sca",
-                                              "syscheck",
-                                              "syscollector",
-                                              "upgrade",
-                                              "vulnerability"
-                                            ]
-                                          },
-                                          "monitor": {
-                                            "type": "integer"
-                                          },
-                                          "remote": {
-                                            "type": "integer"
-                                          }
-                                        },
-                                        "required": [
-                                          "agent",
-                                          "dbsync",
-                                          "modules_breakdown",
-                                          "monitor",
-                                          "remote"
-                                        ]
-                                      }
-                                    },
-                                    "required": [
-                                      "decoded_breakdown"
-                                    ]
-                                  },
-                                  "written_breakdown": {
-                                    "type": "object",
-                                    "properties": {
-                                      "alerts": {
-                                        "type": "integer"
-                                      },
-                                      "archives": {
-                                        "type": "integer"
-                                      },
-                                      "firewall": {
-                                        "type": "integer"
-                                      }
-                                    },
-                                    "required": [
-                                      "alerts",
-                                      "archives",
-                                      "firewall"
-                                    ]
-                                  }
-                                },
-                                "required": [
-                                  "processed",
-                                  "received_breakdown",
-                                  "written_breakdown"
-                                ]
-                              }
-                            },
-                            "required": [
-                              "events"
-                            ]
-                          }
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
                         },
-                        "required": [
-                          "uptime",
-                          "id",
-                          "metrics"
-                        ]
-                      }
-                    ]
+                        "type": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "value": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "name",
+                        "type",
+                        "enabled",
+                        "value"
+                      ]
+                    }
+                  },
+                  "spaces": {
+                    "type": "array"
                   }
                 },
                 "required": [
-                  "timestamp",
                   "name",
-                  "agents"
+                  "uptime",
+                  "timestamp",
+                  "global",
+                  "spaces"
                 ]
               }
             ]


### PR DESCRIPTION
## Description

`test_agent_statistics_format[ANALYSISD_ENDPOINT]` fails schema validation because the agent `wazuh-manager-analysisd` statistics template still expects the legacy analysisd response shape (`agents[].metrics.events`), while `wazuh-manager` v5.0 serves the statistics of this endpoint through the engine's metrics dump format, same as the cluster endpoint updated in #783.

Closes #789.

## Proposed Changes

- Replace the stale `agents[].metrics` schema in the agent `wazuh-manager-analysisd` statistics template with the engine metrics dump shape: a `global` array of `{name, type, enabled, value}` entries, alongside the `name`, `uptime`, `timestamp`, `status` and `spaces` fields, mirroring the cluster template from #783.

### Results and Evidence

Schema validated locally with `jsonschema` (draft-04, the same validator used by `validate_statistics`):

- The real API response attached to #789 validates against the updated template.
- The legacy per-agent shape is correctly rejected.
- A response missing `global` is correctly rejected.

```
PASS  agent_statistics_format_test_module/wazuh-manager-analysisd_template.json: real issue response validates
PASS  agent_statistics_format_test_module/wazuh-manager-analysisd_template.json: legacy shape correctly rejected
PASS  agent_statistics_format_test_module/wazuh-manager-analysisd_template.json: missing global correctly rejected
```

### Artifacts Affected

None.

### Configuration Changes

None.

### Documentation Updates

CHANGELOG.md entry added under the `[v5.0.0]` section.

### Tests Introduced

None. The updated template is consumed by the existing `test_agent_statistics_format` integration test.

## Review Checklist
- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] PR is linked to the relevant issue(s)
- [ ] Correct labels applied (e.g., `no-changelog`)
