### PR TITLE
Merge 4.14.7 into 4.14.8

### DIFF
--- a/.github/workflows/4_codequality_changelog.yml
+++ b/.github/workflows/4_codequality_changelog.yml
@@ -24,5 +24,5 @@ jobs:
         uses: dangoslen/changelog-enforcer@v3
         id: verify-changelog
         with:
-          skipLabels: "autocut,skip-changelog"
+          skipLabels: "autocut,no-changelog"
           changeLogPath: "CHANGELOG.md"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.14.7]
+
+### Changed
+
+- Replaced deprecated `pyOpenSSL` functions in `CertificateController` and `AuthdSimulator` with the `cryptography` API. ([#748](https://github.com/wazuh/qa-integration-framework/pull/748))
+
+### Fixed
+
+- Fixed `authd` flaky tests by running the `ManInTheMiddle` listener thread as a daemon thread. ([#707](https://github.com/wazuh/qa-integration-framework/pull/707))
+
 ## [4.14.6]
 
 ### Changed

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
   "version": "4.14.7",
-  "stage": "alpha0"
+  "stage": "rc1"
 }

--- a/src/wazuh_testing/tools/certificate_controller.py
+++ b/src/wazuh_testing/tools/certificate_controller.py
@@ -8,8 +8,9 @@ import stat
 
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
 from cryptography.x509.oid import NameOID
-from OpenSSL import crypto
 
 if platform.system() == 'Windows':
     import win32api
@@ -28,8 +29,7 @@ class CertificateController:
         """
 
         self.digest = message_digest
-        self.root_ca_key = crypto.PKey()
-        self.root_ca_key.generate_key(crypto.TYPE_RSA, 4096)
+        self.root_ca_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
         self.root_ca_cert = self._create_ca_cert(self.root_ca_key)
 
     def get_root_ca_cert(self):
@@ -50,8 +50,7 @@ class CertificateController:
             key_bits (int): The number of bits for the RSA key. Defaults to 4096.
             signed (bool): Whether to sign the certificate with the root CA key. Defaults to True.
         """
-        key = crypto.PKey()
-        key.generate_key(crypto.TYPE_RSA, key_bits)
+        key = rsa.generate_private_key(public_exponent=65537, key_size=key_bits)
 
         signing_key = self.root_ca_key if signed else key
         cert = self._create_ca_cert(key, subject=agentname, signing_key=signing_key)
@@ -59,24 +58,24 @@ class CertificateController:
         self.store_private_key(key, agent_key_path)
         self.store_ca_certificate(cert, agent_cert_path)
 
-    def _create_ca_cert(self, pub_key: crypto.PKey, issuer: str = "Manager", subject: str = None,
-                        expiration_time: int = 0, signing_key: crypto.PKey = None) -> crypto.X509:
+    def _create_ca_cert(self, pub_key: rsa.RSAPrivateKey, issuer: str = "Manager", subject: str = None,
+                        expiration_time: int = 0, signing_key: rsa.RSAPrivateKey = None) -> x509.Certificate:
         """
         Create a CA certificate using the provided public key.
 
         Args:
-            pub_key (crypto.PKey): The public key for the certificate.
+            pub_key (rsa.RSAPrivateKey): The public key for the certificate.
             issuer (str): The issuer of the certificate. Defaults to "Manager".
             subject (str): The subject of the certificate. If not provided, the issuer is used.
             expiration_time (int): The expiration time of the certificate in seconds.
                 If not provided, it defaults to 10 years.
-            signing_key (crypto.PKey): The key used to sign the certificate.
+            signing_key (rsa.RSAPrivateKey): The key used to sign the certificate.
                 If not provided, the root CA key is used.
 
         Returns:
-            crypto.X509: The created CA certificate.
+            x509.Certificate: The created CA certificate.
         """
-        public_key = pub_key.to_cryptography_key().public_key()
+        public_key = pub_key.public_key()
 
         expiry = expiration_time if expiration_time else 10 * 365 * 24 * 60 * 60
         now = datetime.datetime.now(datetime.timezone.utc)
@@ -93,33 +92,37 @@ class CertificateController:
             .add_extension(x509.SubjectKeyIdentifier.from_public_key(public_key), critical=False)
         )
 
-        signer = (signing_key or self.root_ca_key).to_cryptography_key()
+        signer = signing_key or self.root_ca_key
         cryptography_cert = builder.sign(signer, hashes.SHA256())
 
-        return crypto.X509.from_cryptography(cryptography_cert)
+        return cryptography_cert
 
     @staticmethod
-    def store_private_key(key: crypto.PKey, path: str) -> None:
+    def store_private_key(key: rsa.RSAPrivateKey, path: str) -> None:
         """
         Store a private key in the specified path.
 
         Args:
-            key (crypto.PKey): The private key to store.
+            key (rsa.RSAPrivateKey): The private key to store.
             path (str): The path to store the private key.
         """
         with open(path, 'wb') as f:
-            f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, key))
+            f.write(key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption()
+            ))
         if platform.system() != 'Windows':
             os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
 
     @staticmethod
-    def store_ca_certificate(cert: crypto.X509, path: str) -> None:
+    def store_ca_certificate(cert: x509.Certificate, path: str) -> None:
         """
         Store a CA certificate in the specified path.
 
         Args:
-            cert (crypto.X509): The CA certificate to store.
+            cert (x509.Certificate): The CA certificate to store.
             path (str): The path to store the CA certificate.
         """
         with open(path, 'wb') as f:
-            f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+            f.write(cert.public_bytes(serialization.Encoding.PEM))

--- a/src/wazuh_testing/tools/simulators/authd_simulator.py
+++ b/src/wazuh_testing/tools/simulators/authd_simulator.py
@@ -188,15 +188,10 @@ class AuthdSimulator(BaseSimulator):
         return agent_info
 
     def __generate_certificates(self):
-        """Generates and stores certificates for the root CA.
+        """Stores the root CA certificate and private key at the provided paths.
 
-        It signs the root CA certificate with the root CA private key using
-        the specified digest algorithm.
-        The generated root CA certificate and private key are then stored
-        at the provided paths.
+        The root CA certificate is already signed by CertificateController at construction time.
         """
-        self.cert_controller.root_ca_cert.sign(
-            self.cert_controller.root_ca_key, self.cert_controller.digest)
         self.cert_controller.store_private_key(
             self.cert_controller.root_ca_key, self.key_path)
         self.cert_controller.store_ca_certificate(


### PR DESCRIPTION
## Description

Scheduled weekly upward merge. Part of #791 (Week #30).

Merges branch `4.14.7` into `4.14.8`.

## Proposed Changes

- Merge `origin/4.14.7` into `4.14.8`.

### Results and Evidence

Only conflict was `VERSION.json`, resolved to `4.14.8` (never downgrade the destination). Incoming changes: 4.14.7 version/changelog bump, cryptography-version-update refactor in `certificate_controller.py` / `authd_simulator.py`, and a changelog-workflow label fix.

```
$ git merge origin/4.14.7        # 1 conflict: VERSION.json -> kept 4.14.8
$ git rev-list --count HEAD..origin/4.14.7   -> 0
$ git rev-list --count HEAD..origin/4.14.8   -> 0
$ grep version VERSION.json      -> 4.14.8
```

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
