### PR TITLE
fix(agentd): add HTTPS startup-accepted log pattern

### DIFF
--- a/src/wazuh_testing/modules/agentd/patterns.py
+++ b/src/wazuh_testing/modules/agentd/patterns.py
@@ -5,6 +5,10 @@ from . import PREFIX
 
 # Callback patterns to find events in log file.
 AGENTD_CONNECTED_TO_SERVER = fr'{PREFIX} Connected to the server'
+# HTTPS transport (wazuh/wazuh#37831): the legacy TCP client's "Connected to the server" line has
+# no equivalent on the /control path -- this is the closest milestone, logged once Startup is
+# accepted and the client leaves the Starting state (bridge_on_startup_result(), https_client_bridge.c).
+AGENTD_HTTPS_STARTUP_ACCEPTED = fr'{PREFIX}.*https_client startup accepted'
 AGENTD_UPDATING_STATE_FILE = r'.*Updating state file'
 AGENTD_SENDING_KEEP_ALIVE = r'.*Sending keep alive'
 AGENTD_SENDING_AGENT_NOTIFICATION = r'.*Sending agent notification'


### PR DESCRIPTION
<!--
This template reflects sections that must be included in new Pull requests.
- If a determined section does not apply, it must not be removed but completed with `N/A`.
- Contributions from the community are really appreciated.
-->

## Description

Part of the agent-side HTTPS migration (wazuh/wazuh#37702, epic wazuh/wazuh#37831) and its
integration-test stabilization tracking issue, wazuh/wazuh#38079 ("Refactor failing ITs for
HTTPS protocol and the new RemotedSimulator").

`AGENTD_CONNECTED_TO_SERVER` (`"Connected to the server"`) is a legacy TCP-client log line.
Once an agent connects over the new HTTPS `/control` path (wazuh/wazuh#38012, #38029), that
line is never emitted — the legacy code path that logged it no longer runs. Integration
tests in `wazuh/wazuh` that assert on the agent reaching a connected state have nothing to
match against once the agent is built from the HTTPS-migrated branch.

## Proposed Changes

- Add `AGENTD_HTTPS_STARTUP_ACCEPTED` to `src/wazuh_testing/modules/agentd/patterns.py`,
  matching the `"https_client startup accepted"` line emitted by
  `bridge_on_startup_result()` (`client-agent/src/https_client_bridge.c`) once a `/control`
  Startup request is accepted and the client leaves the `Starting` state.
- No other patterns changed; `AGENTD_CONNECTED_TO_SERVER` is left in place since the legacy
  and HTTPS paths currently run side by side during the migration.

### Results and Evidence

Validated against a real compiled `wazuh-agentd` (built from `wazuh/wazuh`'s
`enhancement/37831-agent-https-client`) driven by this repo's HTTPS `RemotedSimulator`
(same branch as PR #795). On the `wazuh/wazuh` side, `wait_connect()`
(`tests/integration/test_agentd/utils.py`) was updated to accept either the legacy pattern
or this new one, and several `test_agentd` integration suites (initial enrollment,
reconnection/re-enrollment, startup hash gate) pass using it against the real HTTPS agent.
That `wazuh/wazuh` branch (`test/37831-agentd-its-fixes`) is prepared but not yet opened as
a PR.

### Manual tests with their corresponding evidence

- Compilation without warnings on every supported platform
  - [ ] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [ ] Log syntax and correct language review

- Memory tests for Linux
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Coverity
  - [ ] UMDH
- Memory tests for macOS
  - [ ] Leaks
  - [ ] AddressSanitizer

- Decoder/Rule tests _(Wazuh v4.x)_: N/A
- Engine _(Wazuh v5.x and above)_: N/A
- Wazuh server API/Framework: N/A

N/A for the sections above except log/language review — this is a one-line Python regex
constant addition, not compiled/native code.

### Artifacts Affected

- `src/wazuh_testing/modules/agentd/patterns.py` (Python package `wazuh_testing`, consumed
  by `tests/integration` in `wazuh/wazuh`).

### Configuration Changes

N/A

### Tests Introduced

N/A in this repo. This pattern is consumed by `wazuh/wazuh` integration tests (branch
`test/37831-agentd-its-fixes`, not yet opened as a PR), not by a test added here.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [ ] Meets requirements and/or definition of done
- [ ] No unresolved dependencies with other issues
- [ ] ...

Related: wazuh/wazuh#37831, wazuh/wazuh#38079. Base branch is the same as PR #795
(`enhancement/37831-agent-https-client`), which introduced the HTTPS `RemotedSimulator`
this pattern is meant to be asserted against.
