### PR TITLE
Nest all_disabled_wazuh.conf remote block under <legacy>

### DIFF
--- a/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.conf
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.conf
@@ -5,9 +5,12 @@
   </logging>
 
   <remote>
-    <port>1514</port>
-    <protocol>tcp</protocol>
-    <queue_size>131072</queue_size>
+    <legacy>
+      <port>1514</port>
+      <protocol>tcp</protocol>
+      <local_ip>0.0.0.0</local_ip>
+      <queue_size>131072</queue_size>
+    </legacy>
   </remote>
 
   <vulnerability-detection>


### PR DESCRIPTION
The 5.x remoted parser now only accepts <legacy>, <https>, and <agents> as children of <remote>; the pre-5.0 flat layout is rejected with OS_INVALID and the manager refuses to (re)start. This template is read by load_wazuh_basic_configuration (tests/integration/conftest.py in wazuh/wazuh), so every integration suite using that fixture failed to restart the manager once the new parser landed.

Also set legacy.local_ip explicitly to 0.0.0.0: its default changed to 127.0.0.1 (loopback-only) in the new parser, whereas an unset local_ip previously meant accept-from-any-interface. Keeping 0.0.0.0 here preserves that behavior for the shared test template.