### PR TITLE
skip sudo/su wrapper processes in search_process_by_command

### DIFF
--- a/src/wazuh_testing/utils/services.py
+++ b/src/wazuh_testing/utils/services.py
@@ -276,6 +276,9 @@ def check_if_process_is_running(process_name):
     return is_running
 
 
+_WRAPPER_PROCESS_NAMES = {'sudo', 'su', 'doas'}
+
+
 def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
     """Search a process by its command
 
@@ -292,6 +295,13 @@ def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
         TypeError('`search_cmd` must not be an empty string.')
 
     for process in psutil.process_iter(attrs=['pid', 'name', 'cmdline']):
+        # Skip wrapper processes (e.g. sudo): their cmdline includes the wrapped
+        # command's name too, so they can match before the real target process.
+        if process.info['name'] in _WRAPPER_PROCESS_NAMES:
+            continue
+
         command = next((command for command in process.cmdline() if search_cmd in command), None)
         if command:
             return process
+
+    return None


### PR DESCRIPTION
### Problem
search_process_by_command() in qa-integration-framework (src/wazuh_testing/utils/services.py:279) can return the wrong process when the target daemon is launched via sudo. This caused nondeterministic failures in test_process_priority (IT Linux - fim tier-1), where the test measured sudo's priority instead of wazuh-syscheckd's.

Root Cause
The function matches by substring over the full process cmdline, iterating in the non-guaranteed order of psutil.process_iter():


for process in psutil.process_iter(attrs=['pid', 'name', 'cmdline']):
    command = next((command for command in process.cmdline() if search_cmd in command), None)
    if command:
        return process
Since the daemon is launched as sudo /var/ossec/bin/wazuh-syscheckd, sudo's own cmdline also contains the daemon name. Whenever sudo enumerates before the real daemon, the function returns sudo's PID instead.

### Fix
Skip known wrapper processes by exact name before doing the substring match, so iteration continues to the real target process:


```
+_WRAPPER_PROCESS_NAMES = {'sudo', 'su', 'doas'}
+
+
 def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
     ...
     for process in psutil.process_iter(attrs=['pid', 'name', 'cmdline']):
+        # Skip wrapper processes (e.g. sudo): their cmdline includes the wrapped
+        # command's name too, so they can match before the real target process.
+        if process.info['name'] in _WRAPPER_PROCESS_NAMES:
+            continue
+
         command = next((command for command in process.cmdline() if search_cmd in command), None)
         if command:
             return process
+
+    return None
```

This preserves substring-matching semantics for the real target process — no behavior change for existing callers — and doesn't require guessing the daemon's exact invocation shape.

Evidence
Before — CI failure (IT Linux - fim tier-1, prior run):


test_fim/test_files/test_process_priority/test_process_priority.py .....FFFF [24%]

FAILED test_process_priority[process_priority_4_scheduled]  - AssertionError: ...
FAILED test_process_priority[process_priority_4_realtime]   - AssertionError: ...
FAILED test_process_priority[process_priority_-5_scheduled] - AssertionError: ...
FAILED test_process_priority[process_priority_-5_realtime]  - AssertionError: ...

E   AssertionError: Process wazuh-syscheckd has not updated its priority.
E   assert 0 == 4
E    +  where 0 = <built-in function getpriority>(0, 2782)
E    +    and   2782 = psutil.Process(pid=2782, name='sudo', status='sleeping').pid

=== 4 failed, 53 passed, 464 deselected, 1741 warnings in 1795.25s (0:29:55) ===
After — same test, CI run against this exact commit:

Confirmed this run maps to this PR's code:


HEAD_SHA: c6215cc00f12fb7f80a766e5bf610d4d6a3d5783
Module 'fim' matched via pattern 'src/syscheckd/**'
Confirmed qa-integration-framework resolved the fix branch by exact name match:


BRANCH_NAME: fix/38011-search-process-by-command-sudo-wrapper
Result:


test_fim/test_files/test_process_priority/test_process_priority.py .....  [24%]
======== 57 passed, 464 deselected, 1741 warnings in 1776.26s (0:29:36) ========
All 5 test_process_priority cases pass — zero failures, up from 4/57 failing. Same test suite, same CI job, only the search_process_by_command fix changed.



<img width="1141" height="518" alt="image" src="https://github.com/user-attachments/assets/c8577c16-cf53-463e-a470-e91f98c4711c" />
