### PR TITLE
Backport: skip sudo/su/doas wrapper processes in search_process_by_command to 5.0.0

### DIFF
--- a/src/wazuh_testing/utils/services.py
+++ b/src/wazuh_testing/utils/services.py
@@ -276,6 +276,9 @@ def check_if_process_is_running(process_name):
     return is_running
 
 
+_WRAPPER_PROCESS_NAMES = {'sudo', 'su', 'doas'}
+
+
 def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
     """Search a process by its command
 
@@ -292,6 +295,13 @@ def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
         TypeError('`search_cmd` must not be an empty string.')
 
     for process in psutil.process_iter(attrs=['pid', 'name', 'cmdline']):
+        # Skip wrapper processes (e.g. sudo): their cmdline includes the wrapped
+        # command's name too, so they can match before the real target process.
+        if process.info['name'] in _WRAPPER_PROCESS_NAMES:
+            continue
+
         command = next((command for command in process.cmdline() if search_cmd in command), None)
         if command:
             return process
+
+    return None


### PR DESCRIPTION
## Description

Closes #38011

Backport of #805 to the `5.0.0` branch. The original fix was merged into `main`, but the issue
was reported against 5.0.0 (CI job "IT Linux - fim (tier-1)"), so the fix must ship there too.

## Proposed Changes

- Cherry-picked commit 50af7b0c96 from #805 onto `5.0.0`.
- Skips `sudo`/`su`/`doas` wrapper processes in `search_process_by_command()` before the
  substring match, so the real target process (e.g. `wazuh-syscheckd`) is returned instead of
  the wrapper when the daemon is launched via `sudo`.

### Results and Evidence

Same fix already validated in #805 (see that PR for before/after evidence).

### Artifacts Affected

- `src/wazuh_testing/utils/services.py`

### Configuration Changes

N/A

### Tests Introduced

None (see open discussion in #805 about adding regression test coverage).

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Tests cover the new functionality
- [ ] Configuration changes documented
- [ ] Developer documentation reflects the changes
- [x] Meets requirements and/or definition of done
- [x] No unresolved dependencies with other issues
