### PR TITLE
Align all_disabled_wazuh.conf auth block with TLS 1.3

### DIFF
--- a/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.conf
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.conf
@@ -50,12 +50,11 @@
     <use_source_ip>no</use_source_ip>
     <purge>yes</purge>
     <use_password>yes</use_password>
-    <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
+    <ciphers>TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256</ciphers>
     <!-- <ssl_agent_ca></ssl_agent_ca> -->
     <ssl_verify_host>no</ssl_verify_host>
     <ssl_manager_cert>etc/sslmanager.cert</ssl_manager_cert>
     <ssl_manager_key>etc/sslmanager.key</ssl_manager_key>
-    <ssl_auto_negotiate>no</ssl_auto_negotiate>
   </auth>
 
 </wazuh_config>


### PR DESCRIPTION
`wazuh-authd` now hard-enforces TLS 1.3 as its minimum protocol version and validates `<ciphers>` TLS 1.3 ciphersuite names; a legacy OpenSSL cipher-list string like the one this template shipped (`HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH`) is now rejected at manager startup. `<ssl_auto_negotiate>` was also removed entirely — any config still containing it now fails parsing as an unknown element. This template is read by `load_wazuh_basic_configuration` (`tests/integration/conftest.py` in `wazuh/wazuh`), so every integration suite using that fixture failed to (re)start the manager once the new authd parser landed.

Updates `<ciphers>` to `TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256` and drops the `<ssl_auto_negotiate>no</ssl_auto_negotiate>` line.