### PR TITLE
Merge 5.0.0 into 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,57 +6,65 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added patterns for disabled syscollector integration tests. ([#546](https://github.com/wazuh/qa-integration-framework/pull/546))
-- Added new SCA event patterns. ([#600](https://github.com/wazuh/qa-integration-framework/pull/600))
-- Added new patterns for new SCA workflow. ([#464](https://github.com/wazuh/qa-integration-framework/pull/464))
-- Added queue for req messages received in remoted simulator. ([#481](https://github.com/wazuh/qa-integration-framework/pull/481))
-- Added support for agent internal limits in the ack startup. ([#579](https://github.com/wazuh/qa-integration-framework/pull/579))
-- Added indexer block to make indexer-connector mandatory. ([#537](https://github.com/wazuh/qa-integration-framework/pull/537))
-- Added bumper workflow for 5.X. ([#413](https://github.com/wazuh/qa-integration-framework/pull/413))
-- Added workflow for automate the bump process in main. ([#391](https://github.com/wazuh/qa-integration-framework/pull/391))
-- Added version file for package installation in default branch. ([#305](https://github.com/wazuh/qa-integration-framework/pull/305))
-- Added `--set-as-main` flag support to repository bumper. ([#620](https://github.com/wazuh/qa-integration-framework/pull/620))
-- Added support for running AWS integration tests on agent. ([#684](https://github.com/wazuh/qa-integration-framework/pull/684))
+| Issue | Comment |
+|-------|---------|
+| [#546](https://github.com/wazuh/qa-integration-framework/pull/546) | Added patterns for disabled syscollector integration tests. |
+| [#600](https://github.com/wazuh/qa-integration-framework/pull/600) | Added new SCA event patterns. |
+| [#464](https://github.com/wazuh/qa-integration-framework/pull/464) | Added new patterns for new SCA workflow. |
+| [#481](https://github.com/wazuh/qa-integration-framework/pull/481) | Added queue for req messages received in remoted simulator. |
+| [#579](https://github.com/wazuh/qa-integration-framework/pull/579) | Added support for agent internal limits in the ack startup. |
+| [#537](https://github.com/wazuh/qa-integration-framework/pull/537) | Added indexer block to make indexer-connector mandatory. |
+| [#413](https://github.com/wazuh/qa-integration-framework/pull/413) | Added bumper workflow for 5.X. |
+| [#391](https://github.com/wazuh/qa-integration-framework/pull/391) | Added workflow for automate the bump process in main. |
+| [#305](https://github.com/wazuh/qa-integration-framework/pull/305) | Added version file for package installation in default branch. |
+| [#620](https://github.com/wazuh/qa-integration-framework/pull/620) | Added `--set-as-main` flag support to repository bumper. |
+| [#684](https://github.com/wazuh/qa-integration-framework/pull/684) | Added support for running AWS integration tests on agent. |
 
 ### Changed
 
-- Adapted qa integration framework to new agent module startup. ([#595](https://github.com/wazuh/qa-integration-framework/pull/595))
-- Migrated certificate generation to the `cryptography` API to keep up with pyOpenSSL 26.2.0 deprecations. ([#683](https://github.com/wazuh/qa-integration-framework/pull/683))
-- Adapted Inventory patterns to use new sync protocol module. ([#468](https://github.com/wazuh/qa-integration-framework/pull/468))
-- Adapted FIM patterns to use new sync protocol module. ([#440](https://github.com/wazuh/qa-integration-framework/pull/440))
-- Renamed the usage of server to manager. ([#597](https://github.com/wazuh/qa-integration-framework/pull/597))
-- Renamed config/log paths manager after separation. ([#576](https://github.com/wazuh/qa-integration-framework/pull/576))
-- Modified all_disabled_ossec.conf file. ([#596](https://github.com/wazuh/qa-integration-framework/pull/596))
-- Enabled cluster by default. ([#509](https://github.com/wazuh/qa-integration-framework/pull/509))
-- Updated states persistence patterns and fixes. ([#465](https://github.com/wazuh/qa-integration-framework/pull/465))
-- Demoted SCA and logcollector tests. ([#612](https://github.com/wazuh/qa-integration-framework/pull/612))
-- Support manager naming changes. ([#592](https://github.com/wazuh/qa-integration-framework/pull/592))
-- Updated the analysisd statistics template to the engine metrics dump format. ([#783](https://github.com/wazuh/qa-integration-framework/pull/783))
-- Updated the agent analysisd statistics template to the engine metrics dump format. ([#790](https://github.com/wazuh/qa-integration-framework/pull/790))
+| Issue | Comment |
+|-------|---------|
+| [#595](https://github.com/wazuh/qa-integration-framework/pull/595) | Adapted qa integration framework to new agent module startup. |
+| [#683](https://github.com/wazuh/qa-integration-framework/pull/683) | Migrated certificate generation to the `cryptography` API to keep up with pyOpenSSL 26.2.0 deprecations. |
+| [#468](https://github.com/wazuh/qa-integration-framework/pull/468) | Adapted Inventory patterns to use new sync protocol module. |
+| [#440](https://github.com/wazuh/qa-integration-framework/pull/440) | Adapted FIM patterns to use new sync protocol module. |
+| [#597](https://github.com/wazuh/qa-integration-framework/pull/597) | Renamed the usage of server to manager. |
+| [#576](https://github.com/wazuh/qa-integration-framework/pull/576) | Renamed config/log paths manager after separation. |
+| [#596](https://github.com/wazuh/qa-integration-framework/pull/596) | Modified all_disabled_ossec.conf file. |
+| [#509](https://github.com/wazuh/qa-integration-framework/pull/509) | Enabled cluster by default. |
+| [#465](https://github.com/wazuh/qa-integration-framework/pull/465) | Updated states persistence patterns and fixes. |
+| [#612](https://github.com/wazuh/qa-integration-framework/pull/612) | Demoted SCA and logcollector tests. |
+| [#592](https://github.com/wazuh/qa-integration-framework/pull/592) | Support manager naming changes. |
+| [#783](https://github.com/wazuh/qa-integration-framework/pull/783) | Updated the analysisd statistics template to the engine metrics dump format. |
+| [#790](https://github.com/wazuh/qa-integration-framework/pull/790) | Updated the agent analysisd statistics template to the engine metrics dump format. |
 
 ### Removed
 
-- Removed wazuh-execd from manager daemon lists. ([#585](https://github.com/wazuh/qa-integration-framework/pull/585))
-- Removed Wazuh Manager deprecated daemons and CLI tools. ([#470](https://github.com/wazuh/qa-integration-framework/pull/470))
-- Removed agent-auth references. ([#444](https://github.com/wazuh/qa-integration-framework/pull/444))
-- Removed osquery references. ([#442](https://github.com/wazuh/qa-integration-framework/pull/442))
-- Removed ciscat references. ([#443](https://github.com/wazuh/qa-integration-framework/pull/443))
-- Removed use of deprecated `manage_agents` binary. ([#439](https://github.com/wazuh/qa-integration-framework/pull/439))
-- Removed Tier 3 OS: Deprecate specials. ([#483](https://github.com/wazuh/qa-integration-framework/pull/483))
-- Removed resources related to deprecated VD tests. ([#473](https://github.com/wazuh/qa-integration-framework/pull/473))
-- Removed integrations from test coverage. ([#463](https://github.com/wazuh/qa-integration-framework/pull/463))
-- Removed sca from remoted sent statistics. ([#523](https://github.com/wazuh/qa-integration-framework/pull/523))
-- Removed default group from remoted_simulator STARTUP response. ([#589](https://github.com/wazuh/qa-integration-framework/pull/589))
-- Removed syslog/labels from manager ITs. ([#602](https://github.com/wazuh/qa-integration-framework/pull/602))
-- Removed references to 4.12.2 and updated changelog main. ([#379](https://github.com/wazuh/qa-integration-framework/pull/379))
+| Issue | Comment |
+|-------|---------|
+| [#585](https://github.com/wazuh/qa-integration-framework/pull/585) | Removed wazuh-execd from manager daemon lists. |
+| [#470](https://github.com/wazuh/qa-integration-framework/pull/470) | Removed Wazuh Manager deprecated daemons and CLI tools. |
+| [#444](https://github.com/wazuh/qa-integration-framework/pull/444) | Removed agent-auth references. |
+| [#442](https://github.com/wazuh/qa-integration-framework/pull/442) | Removed osquery references. |
+| [#443](https://github.com/wazuh/qa-integration-framework/pull/443) | Removed ciscat references. |
+| [#439](https://github.com/wazuh/qa-integration-framework/pull/439) | Removed use of deprecated `manage_agents` binary. |
+| [#483](https://github.com/wazuh/qa-integration-framework/pull/483) | Removed Tier 3 OS: Deprecate specials. |
+| [#473](https://github.com/wazuh/qa-integration-framework/pull/473) | Removed resources related to deprecated VD tests. |
+| [#463](https://github.com/wazuh/qa-integration-framework/pull/463) | Removed integrations from test coverage. |
+| [#523](https://github.com/wazuh/qa-integration-framework/pull/523) | Removed sca from remoted sent statistics. |
+| [#589](https://github.com/wazuh/qa-integration-framework/pull/589) | Removed default group from remoted_simulator STARTUP response. |
+| [#602](https://github.com/wazuh/qa-integration-framework/pull/602) | Removed syslog/labels from manager ITs. |
+| [#379](https://github.com/wazuh/qa-integration-framework/pull/379) | Removed references to 4.12.2 and updated changelog main. |
 
 ### Fixed
 
-- Fixed integration tests after ossec terminology removal. ([#611](https://github.com/wazuh/qa-integration-framework/pull/611))
-- Fixed syscollector config pattern. ([#482](https://github.com/wazuh/qa-integration-framework/pull/482))
-- Fixed Python unit test coverage script. ([#345](https://github.com/wazuh/qa-integration-framework/pull/345))
-- Fixed server clean up minor issues. ([#615](https://github.com/wazuh/qa-integration-framework/pull/615))
-- Increased net stop retries and force kill process as last resort. ([#621](https://github.com/wazuh/qa-integration-framework/pull/621))
+| Issue | Comment |
+|-------|---------|
+| [#611](https://github.com/wazuh/qa-integration-framework/pull/611) | Fixed integration tests after ossec terminology removal. |
+| [#482](https://github.com/wazuh/qa-integration-framework/pull/482) | Fixed syscollector config pattern. |
+| [#345](https://github.com/wazuh/qa-integration-framework/pull/345) | Fixed Python unit test coverage script. |
+| [#615](https://github.com/wazuh/qa-integration-framework/pull/615) | Fixed server clean up minor issues. |
+| [#621](https://github.com/wazuh/qa-integration-framework/pull/621) | Increased net stop retries and force kill process as last resort. |
 
 ## Prior versions
 

--- a/VERSION.json
+++ b/VERSION.json
@@ -1,4 +1,4 @@
 {
-  "version": "4.14.8",
+  "version": "4.14.9",
   "stage": "alpha0"
 }

--- a/src/wazuh_testing/utils/services.py
+++ b/src/wazuh_testing/utils/services.py
@@ -276,6 +276,9 @@ def check_if_process_is_running(process_name):
     return is_running
 
 
+_WRAPPER_PROCESS_NAMES = {'sudo', 'su', 'doas'}
+
+
 def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
     """Search a process by its command
 
@@ -292,6 +295,13 @@ def search_process_by_command(search_cmd: str) -> Union[psutil.Process, None]:
         TypeError('`search_cmd` must not be an empty string.')
 
     for process in psutil.process_iter(attrs=['pid', 'name', 'cmdline']):
+        # Skip wrapper processes (e.g. sudo): their cmdline includes the wrapped
+        # command's name too, so they can match before the real target process.
+        if process.info['name'] in _WRAPPER_PROCESS_NAMES:
+            continue
+
         command = next((command for command in process.cmdline() if search_cmd in command), None)
         if command:
             return process
+
+    return None

--- a/tools/repository_bumper.sh
+++ b/tools/repository_bumper.sh
@@ -65,9 +65,77 @@ update_version_file() {
     echo "$VERSION_FILE: version $current_version -> $new_v, stage $current_stage -> $new_s" | tee -a "$LOGFILE"
 }
 
+update_changelog() {
+    local changelog_file="CHANGELOG.md"
+    local repo_url="https://github.com/wazuh/qa-integration-framework"
+
+    [ -z "$new_version" ] && return 0
+
+    # Skeleton for the new version: every block heading with an empty table
+    # ready to receive entries.
+    local table_header=$'| Issue | Comment |\n|-------|---------|'
+    local skeleton=$'# Changelog\n\nAll notable changes to this project will be documented in this file.\n\n'"## [v${new_version}]"
+    local block
+    for block in Added Changed Removed Fixed; do
+        skeleton+=$'\n\n'"### ${block}"$'\n\n'"${table_header}"
+    done
+
+    if [ ! -f "$changelog_file" ]; then
+        echo "$skeleton" > "$changelog_file"
+        echo "$changelog_file: created with version $new_version" | tee -a "$LOGFILE"
+        return 0
+    fi
+
+    local version_escaped="${new_version//./\\.}"
+    if grep -qE "^## \[v?${version_escaped}\]" "$changelog_file"; then
+        echo "$changelog_file: version $new_version already present, skipping" | tee -a "$LOGFILE"
+        return 0
+    fi
+
+    # Candidate prior versions: every version section being replaced by a link
+    # plus the versions already listed under "## Prior versions", newest first.
+    local candidates
+    candidates=$(
+        {
+            grep -E '^## \[v?[0-9]+\.[0-9]+\.[0-9]+\]' "$changelog_file" \
+                | sed -E 's/^## \[v?([0-9]+\.[0-9]+\.[0-9]+)\].*/\1/'
+            sed -n '/^## Prior versions/,$p' "$changelog_file" \
+                | grep -oE 'v?[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^v//'
+        } | sort -Vru || true
+    )
+
+    # Ignore versions older than 5.0.0 and keep every version belonging to the
+    # two latest minor series.
+    local prior_tags
+    prior_tags=$(awk -F. -v min_major=5 '
+        NF < 3 { next }
+        $1 < min_major { next }
+        { mm = $1 "." $2 }
+        !(mm in minors) {
+            if (nminors == 2) next
+            minors[mm]; nminors++
+        }
+        { print }' <<< "$candidates")
+
+    # Rebuild the changelog: the new version skeleton plus the prior-version links.
+    local new_content="$skeleton"
+    if [ -n "$prior_tags" ]; then
+        new_content+=$'\n\n'"## Prior versions"$'\n'
+        local tag
+        while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            new_content+=$'\n'"- [v${tag}](${repo_url}/blob/v${tag}/CHANGELOG.md)"
+        done <<< "$prior_tags"
+    fi
+
+    echo "$new_content" > "$changelog_file"
+    echo "$changelog_file: rebuilt for version $new_version" | tee -a "$LOGFILE"
+}
+
 # ---- Main ----
 
 parse_args "$@"
 
 echo "Modified files:" | tee "$LOGFILE"
 update_version_file
+update_changelog


### PR DESCRIPTION
## Description

Scheduled weekly upward merge. Part of #810 (Week #32). Merges `5.0.0` into `5.0.1`.

Single merge commit; 5.0.1 is authoritative.

## Proposed Changes

- Merge `origin/5.0.0` into `5.0.1`.

### Results and Evidence

9 commits of 5.0.0 carried into 5.0.1 (service helpers, repository_bumper, changelog). Auto-merge with no conflicts (`ort` strategy). `CHANGELOG.md` was reconciled to 5.0.0's table format (introduced by #38075): all 42 referenced entries from 5.0.1's previous bullet-list are preserved in the table format, plus 5.0.0's newer entries. Verified no 5.0.1-unique entry was dropped.

```
$ git merge origin/5.0.0        # Merge made by the 'ort' strategy, no conflicts
$ git rev-list --count HEAD..origin/5.0.0   -> 0
$ git rev-list --count HEAD..origin/5.0.1   -> 0
$ cat VERSION.json              -> {"version": "5.0.1", "stage": "alpha0"}
```

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
