### PR TITLE
Drop pre-5.0.0 prior versions from the 5.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,15 +65,3 @@ All notable changes to this project will be documented in this file.
 | [#345](https://github.com/wazuh/qa-integration-framework/pull/345) | Fixed Python unit test coverage script. |
 | [#615](https://github.com/wazuh/qa-integration-framework/pull/615) | Fixed server clean up minor issues. |
 | [#621](https://github.com/wazuh/qa-integration-framework/pull/621) | Increased net stop retries and force kill process as last resort. |
-
-## Prior versions
-
-- [v4.14.5](https://github.com/wazuh/qa-integration-framework/blob/v4.14.5/CHANGELOG.md)
-- [v4.14.4](https://github.com/wazuh/qa-integration-framework/blob/v4.14.4/CHANGELOG.md)
-- [v4.14.3](https://github.com/wazuh/qa-integration-framework/blob/v4.14.3/CHANGELOG.md)
-- [v4.14.2](https://github.com/wazuh/qa-integration-framework/blob/v4.14.2/CHANGELOG.md)
-- [v4.14.1](https://github.com/wazuh/qa-integration-framework/blob/v4.14.1/CHANGELOG.md)
-- [v4.14.0](https://github.com/wazuh/qa-integration-framework/blob/v4.14.0/CHANGELOG.md)
-- [v4.13.1](https://github.com/wazuh/qa-integration-framework/blob/v4.13.1/CHANGELOG.md)
-- [v4.13.0](https://github.com/wazuh/qa-integration-framework/blob/v4.13.0/CHANGELOG.md)
-


### PR DESCRIPTION
## Description

Part of #810.

The `5.0.0` `CHANGELOG.md` listed `v4.14.x`/`v4.13.x` releases under `## Prior versions`. The prior-versions list must only reference the two latest minor series and nothing older than `5.0.0`; for `5.0.0` there is no such prior version, so the section should not exist (it is absent in the `wazuh/wazuh` `5.0.0` changelog too).

## Proposed Changes

- Remove the `## Prior versions` section and its pre-`5.0.0` links from `CHANGELOG.md`.
- The `## [v5.0.0]` block and its 42 entries are unchanged.

### Results and Evidence

```
$ grep -cE 'Prior versions|blob/v4\.' CHANGELOG.md   -> 0
$ grep -c '^| \[' CHANGELOG.md                        -> 42   (v5.0.0 entries intact)
```

Does not affect the upward merges: each version regenerates its own prior-versions list on bump, and `5.0.1`/`main` already list the correct links independently.

## Review Checklist

- [x] Code changes reviewed
- [x] Relevant evidence provided
