### PR TITLE
Add zstd decomporession support for RemotedSimulator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ urllib3>=1.26.2
 distro>=1.8.0
 boto3>=1.34.28
 pyarrow>=14.0.1
+zstandard>=0.21.0

--- a/src/wazuh_testing/tools/https_server.py
+++ b/src/wazuh_testing/tools/https_server.py
@@ -17,7 +17,9 @@ import ssl
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
+
+from zstandard import ZstdDecompressor
 
 from wazuh_testing.tools.certificate_controller import CertificateController
 
@@ -114,6 +116,37 @@ class BaseTLSRequestHandler(BaseHTTPRequestHandler):
         if length is None:
             return b''
         return self.rfile.read(int(length))
+
+    def decode_body(self, body: bytes) -> Tuple[bytes, Optional[Tuple[int, str]]]:
+        """Undo the request's ``Content-Encoding``, if it has one.
+
+        Args:
+            body (bytes): The raw request body, exactly as read off the socket.
+
+        Returns:
+            Tuple[bytes, Optional[Tuple[int, str]]]: ``(decoded, error)``. ``error`` is
+            None on success. Otherwise it is the ``(status, message)`` pair the caller
+            should answer with, and ``decoded`` is the untouched input.
+
+        An encoding this server cannot undo is a 415, because that is what a server
+        without support answers and clients are expected to retry uncompressed. A body
+        that claims ``zstd`` but fails to decode is a 400 instead: the encoding was
+        understood, the payload was simply broken.
+        """
+        encoding = self.headers.get('Content-Encoding', '').strip().lower()
+
+        if not encoding or encoding == 'identity':
+            return body, None
+
+        if encoding != 'zstd':
+            return body, (415, f'Unsupported Content-Encoding: {encoding}')
+
+        try:
+            # decompressobj() rather than decompress(): a frame whose header carries no
+            # pledged content size (what the streaming compressor emits) still decodes.
+            return ZstdDecompressor().decompressobj().decompress(body), None
+        except Exception:
+            return body, (400, 'Malformed zstd body')
 
     def _read_chunked_body(self) -> bytes:
         """De-chunk an HTTP/1.1 ``Transfer-Encoding: chunked`` body."""

--- a/src/wazuh_testing/tools/simulators/remoted_simulator.py
+++ b/src/wazuh_testing/tools/simulators/remoted_simulator.py
@@ -159,16 +159,26 @@ class _RemotedRequestHandler(BaseTLSRequestHandler):
 
     def do_POST(self) -> None:
         """Handle every agent request (all endpoints are POST)."""
-        body = self.read_body()
+        raw_body = self.read_body()
         path = urlsplit(self.path).path
         self._authenticated_agent_id = None
+
+        # The agent compresses before signing, so its CMAC covers the encoded bytes:
+        # _verify_auth() below keeps the raw body, everything else uses the decoded one
+        # (including record_request, so tests read what the agent meant to send whether
+        # or not the body arrived compressed).
+        body, encoding_error = self.decode_body(raw_body)
 
         self.simulator.record_request('POST', self.path, self.headers, body)
 
         if self._inject_fault():
             return
 
-        if not self._verify_auth(body):
+        if encoding_error is not None:
+            self.send_error_response(*encoding_error)
+            return
+
+        if not self._verify_auth(raw_body):
             return
 
         if path == CONTROL_ENDPOINT:


### PR DESCRIPTION
## Description

The remoted simulator could not read request bodies sent with `Content-Encoding: zstd`. Agents compress by default from https://github.com/wazuh/wazuh/issues/38434 onward, so every body now arrives as a zstd frame.

## Proposed Changes

Request bodies are decoded before being routed, so simulators see what the agent meant to send regardless of how it was encoded. An encoding the simulator cannot undo is answered with `415`, which is what a manager without support sends and what makes the agent fall back to uncompressed.

### Results and Evidence

Fixes these, which fail with `Connected to the server message not found` against an agent with compression enabled:

``` bash
test_agentd/test_reconnection/test_agentd_connection_retries_pre_enrollment.py
test_agentd/test_reconnection/test_agentd_initial_enrollment_retries.py
test_agentd/test_reconnection/test_agentd_reconection_enrollment_no_keys.py
test_agentd/test_reconnection/test_agentd_reconection_enrollment_no_keys_file.py
test_agentd/test_reconnection/test_agentd_reconection_enrollment_with_keys.py
test_agentd/test_state/test_agentd_state.py
```

### Configuration Changes

New `zstandard` dependency: existing virtualenvs and CI images need a reinstall before these tests pass.

### Dependencies

Must merge before https://github.com/wazuh/wazuh/issues/38434, which enables agent-side compression.

## Review Checklist

- [ ] Code changes reviewed
- [ ] Relevant evidence provided
- [ ] Meets requirements and/or definition of done
