### PR TITLE
Update the manager socket constants for the new queue/sockets layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 | [#592](https://github.com/wazuh/qa-integration-framework/pull/592) | Support manager naming changes. |
 | [#783](https://github.com/wazuh/qa-integration-framework/pull/783) | Updated the analysisd statistics template to the engine metrics dump format. |
 | [#790](https://github.com/wazuh/qa-integration-framework/pull/790) | Updated the agent analysisd statistics template to the engine metrics dump format. |
+| [#834](https://github.com/wazuh/qa-integration-framework/pull/834) | Updated the manager socket constants to the standardized `queue/sockets` layout. |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 | Issue | Comment |
 |-------|---------|
 | [#585](https://github.com/wazuh/qa-integration-framework/pull/585) | Removed wazuh-execd from manager daemon lists. |
+| [#834](https://github.com/wazuh/qa-integration-framework/pull/834) | Removed the socket constants for sockets the manager no longer creates. |
 | [#470](https://github.com/wazuh/qa-integration-framework/pull/470) | Removed Wazuh Manager deprecated daemons and CLI tools. |
 | [#444](https://github.com/wazuh/qa-integration-framework/pull/444) | Removed agent-auth references. |
 | [#442](https://github.com/wazuh/qa-integration-framework/pull/442) | Removed osquery references. |

--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -21,19 +21,16 @@ AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth.sock')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
 MODULESD_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules')
-MODULESD_DOWNLOAD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'download')
 MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
 # The manager renamed these two; the agent keeps the legacy names, so each product
 # needs its own constant.
 MANAGER_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules.sock')
 MANAGER_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control.sock')
-MODULESD_KREQUEST_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'krequest')
 MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'cluster-internal.sock')
 MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor.sock')
 REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote.sock')
 SYSCHECKD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'syscheck')
 WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wdb.sock')
-ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'ar')
 
 
 WAZUH_SOCKETS = {
@@ -51,9 +48,7 @@ WAZUH_SOCKETS = {
     'wazuh-manager-db': [WAZUH_DB_SOCKET_PATH],
     'wazuh-modulesd': [
         MODULESD_WMODULES_SOCKET_PATH,
-        MODULESD_DOWNLOAD_SOCKET_PATH,
         MODULESD_CONTROL_SOCKET_PATH,
-        MODULESD_KREQUEST_SOCKET_PATH
     ],
     'wazuh-manager-modulesd': [
         MANAGER_WMODULES_SOCKET_PATH,
@@ -64,6 +59,5 @@ WAZUH_SOCKETS = {
 
 # These sockets do not exist with default Wazuh configuration
 WAZUH_OPTIONAL_SOCKETS = [
-    MODULESD_KREQUEST_SOCKET_PATH,
     AUTHD_SOCKET_PATH
 ]

--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -15,20 +15,24 @@ QUEUE_RIDS_PATH = os.path.join(WAZUH_PATH, 'queue', 'rids')
 QUEUE_ALERTS_PATH = os.path.join(WAZUH_PATH, 'queue', 'alerts')
 DIFF_PATH_FILE = os.path.join(QUEUE_DIFF_PATH, 'file')
 
-ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
+ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'engine-api-http.sock')
 ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
-AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
+AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth.sock')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
 MODULESD_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules')
 MODULESD_DOWNLOAD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'download')
 MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
+# The manager renamed these two; the agent keeps the legacy names, so each product
+# needs its own constant.
+MANAGER_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules.sock')
+MANAGER_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control.sock')
 MODULESD_KREQUEST_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'krequest')
-MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_CLUSTER_PATH, 'c-internal.sock')
-MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor')
-REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote')
+MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'cluster-internal.sock')
+MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor.sock')
+REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote.sock')
 SYSCHECKD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'syscheck')
-WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_DB_PATH, 'wdb')
+WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wdb.sock')
 ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'ar')
 
 
@@ -52,8 +56,8 @@ WAZUH_SOCKETS = {
         MODULESD_KREQUEST_SOCKET_PATH
     ],
     'wazuh-manager-modulesd': [
-        MODULESD_WMODULES_SOCKET_PATH,
-        MODULESD_CONTROL_SOCKET_PATH,
+        MANAGER_WMODULES_SOCKET_PATH,
+        MANAGER_CONTROL_SOCKET_PATH,
     ],
     'wazuh-manager-clusterd': [MODULESD_C_INTERNAL_SOCKET_PATH]
 }

--- a/src/wazuh_testing/utils/sockets.py
+++ b/src/wazuh_testing/utils/sockets.py
@@ -7,7 +7,6 @@ import ipaddress
 
 from wazuh_testing.tools.socket_controller import SocketController
 from wazuh_testing.constants.paths.sockets import QUEUE_SOCKETS_PATH, WAZUH_DB_SOCKET_PATH, \
-                                                  MODULESD_C_INTERNAL_SOCKET_PATH, \
                                                   ACTIVE_RESPONSE_SOCKET_PATH
 from wazuh_testing.utils.network import UDP
 
@@ -23,10 +22,6 @@ def delete_sockets(path=None):
             path = QUEUE_SOCKETS_PATH
             for file in os.listdir(path):
                 os.remove(os.path.join(path, file))
-            if os.path.exists(WAZUH_DB_SOCKET_PATH):
-                os.remove(WAZUH_DB_SOCKET_PATH)
-            if os.path.exists(MODULESD_C_INTERNAL_SOCKET_PATH):
-                os.remove(MODULESD_C_INTERNAL_SOCKET_PATH)
         else:
             for item in path:
                 os.remove(item)

--- a/src/wazuh_testing/utils/sockets.py
+++ b/src/wazuh_testing/utils/sockets.py
@@ -16,16 +16,18 @@ def delete_sockets(path=None):
     Args:
         path (list, optional): Absolute socket path. Default `None`.
     """
-    try:
-        if path is None:
-            path = QUEUE_SOCKETS_PATH
-            for file in os.listdir(path):
-                os.remove(os.path.join(path, file))
-        else:
-            for item in path:
-                os.remove(item)
-    except FileNotFoundError:
-        pass
+    if path is None:
+        try:
+            path = [os.path.join(QUEUE_SOCKETS_PATH, file) for file in os.listdir(QUEUE_SOCKETS_PATH)]
+        except FileNotFoundError:
+            return
+
+    # An absent socket must not stop the removal of the rest.
+    for item in path:
+        try:
+            os.remove(item)
+        except FileNotFoundError:
+            pass
 
 def send_request_socket(query, socket_path=WAZUH_DB_SOCKET_PATH):
     """Send queries request to socket in the argument.

--- a/src/wazuh_testing/utils/sockets.py
+++ b/src/wazuh_testing/utils/sockets.py
@@ -6,8 +6,7 @@ import socket
 import ipaddress
 
 from wazuh_testing.tools.socket_controller import SocketController
-from wazuh_testing.constants.paths.sockets import QUEUE_SOCKETS_PATH, WAZUH_DB_SOCKET_PATH, \
-                                                  ACTIVE_RESPONSE_SOCKET_PATH
+from wazuh_testing.constants.paths.sockets import QUEUE_SOCKETS_PATH, WAZUH_DB_SOCKET_PATH
 from wazuh_testing.utils.network import UDP
 
 
@@ -74,19 +73,6 @@ def send_message_to_syslog_socket(message, port, protocol, manager_address="127.
 
     sock.connect((manager_address, port))
     sock.send(message.encode())
-    sock.close()
-
-
-def send_active_response_message(active_response_command):
-    """Send active response message to `/var/ossec/queue/alerts/ar` socket.
-
-    Args:
-        active_response_command (str): Active response message.
-    """
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-
-    sock.connect(ACTIVE_RESPONSE_SOCKET_PATH)
-    sock.send(f"{active_response_command}".encode())
     sock.close()
 
 


### PR DESCRIPTION
## Problem

wazuh/wazuh#38436 renames the manager's Unix sockets and gathers them all in `queue/sockets/`, implemented in wazuh/wazuh#38551. This repository declares its own copy of those paths in `src/wazuh_testing/constants/paths/sockets.py`, so any test resolving a socket through them would connect to a path that no longer exists.

## What this changes

Eight constant values. No constant is renamed: wazuh/wazuh integration tests import several of them by name.

| Constant | Before | After |
|---|---|---|
| `ANALYSISD_ANALISIS_SOCKET_PATH` | `sockets/analysis` | `sockets/engine-api-http.sock` |
| `AUTHD_SOCKET_PATH` | `sockets/auth` | `sockets/auth.sock` |
| `MONITORD_SOCKET_PATH` | `sockets/monitor` | `sockets/monitor.sock` |
| `REMOTED_SOCKET_PATH` | `sockets/remote` | `sockets/remote.sock` |
| `WAZUH_DB_SOCKET_PATH` | `db/wdb` | `sockets/wdb.sock` |
| `MODULESD_C_INTERNAL_SOCKET_PATH` | `cluster/c-internal.sock` | `sockets/cluster-internal.sock` |
| `MANAGER_WMODULES_SOCKET_PATH` | new | `sockets/wmodules.sock` |
| `MANAGER_CONTROL_SOCKET_PATH` | new | `sockets/control.sock` |

`control` and `wmodules` are the only sockets both products create, and wazuh/wazuh renames them on the manager only, behind `#ifdef CLIENT`. `WAZUH_SOCKETS` already keyed `wazuh-modulesd` and `wazuh-manager-modulesd` apart, so the `MODULESD_*` constants keep the agent's names and the new `MANAGER_*` ones carry the manager's.

`delete_sockets` no longer removes `WAZUH_DB_SOCKET_PATH` and `MODULESD_C_INTERNAL_SOCKET_PATH` explicitly: both are inside `queue/sockets` now, so its sweep of that directory covers them. For the same reason `delete_dbs` stops taking the wdb socket down with the databases.

Same function, one fix: it caught `FileNotFoundError` outside its loop, so the first absent socket skipped every remaining removal and left the rest of the daemon's sockets on disk for the next test. The handling moves inside the loop, and the directory listing now feeds the same loop the explicit path uses. `control_service('stop', daemon=...)` passes a whole `WAZUH_SOCKETS` list, so this is what makes growing any of those lists safe.

Also deleted: `download`, `krequest` and `ar`, three constants naming sockets 5.0.0 does not create (`ar` left the product in `f2cdb3db38`), plus `send_active_response_message`, their only consumer.

Agent-only sockets keep their names, since wazuh/wazuh left them for a follow-up: `queue`, `com`, `logcollector`, `syscheck`. `QUEUE_DB_PATH` and `QUEUE_CLUSTER_PATH` stay, because only the sockets left those directories.

## Evidence

No old manager socket name survives under `src/`, the removed names are gone from the whole tree, and `pyflakes` reports no orphaned import in either edited file. Every path the framework still declares was compared against the macros in `src/shared/include/defs.h` and the constants in `framework/wazuh/core/common.py` on the wazuh branch: 16 matches, 0 mismatches. `WAZUH_SOCKETS` resolves to `['wmodules', 'control']` for `wazuh-modulesd` and `['wmodules.sock', 'control.sock']` for `wazuh-manager-modulesd`.

The integration tests need a manager built from wazuh/wazuh#38551, so they were not run. This repository has no unit test suite, so the import check is the full extent of what runs here.

## Reported, not fixed here

1. `WAZUH_SOCKETS['wazuh-manager-modulesd']` lists two sockets where manager modulesd binds seven, adding `task.sock`, `task-upgrade.sock`, `keystore.sock`, `vd-http.sock` and `inventory-sync-http.sock`. Six are unconditional; `vd-http.sock` only registers when the configuration carries a `<vulnerability-detection>` section, so settling the list needs a running manager.
2. `wazuh-qa-automation` keeps a near-identical copy of this file, with the same logic and the same dead constants: wazuh/wazuh-qa-automation#8714.

Related: wazuh/wazuh#38436
Depends on: wazuh/wazuh#38551