### PR TITLE
Merge 5.0.0 into 5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable changes to this project will be documented in this file.
 | [#592](https://github.com/wazuh/qa-integration-framework/pull/592) | Support manager naming changes. |
 | [#783](https://github.com/wazuh/qa-integration-framework/pull/783) | Updated the analysisd statistics template to the engine metrics dump format. |
 | [#790](https://github.com/wazuh/qa-integration-framework/pull/790) | Updated the agent analysisd statistics template to the engine metrics dump format. |
+| [#834](https://github.com/wazuh/qa-integration-framework/pull/834) | Updated the manager socket constants to the standardized `queue/sockets` layout. |
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 | Issue | Comment |
 |-------|---------|
 | [#585](https://github.com/wazuh/qa-integration-framework/pull/585) | Removed wazuh-execd from manager daemon lists. |
+| [#834](https://github.com/wazuh/qa-integration-framework/pull/834) | Removed the socket constants for sockets the manager no longer creates. |
 | [#470](https://github.com/wazuh/qa-integration-framework/pull/470) | Removed Wazuh Manager deprecated daemons and CLI tools. |
 | [#444](https://github.com/wazuh/qa-integration-framework/pull/444) | Removed agent-auth references. |
 | [#442](https://github.com/wazuh/qa-integration-framework/pull/442) | Removed osquery references. |

--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -21,19 +21,16 @@ AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth.sock')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
 MODULESD_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules')
-MODULESD_DOWNLOAD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'download')
 MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
 # The manager renamed these two; the agent keeps the legacy names, so each product
 # needs its own constant.
 MANAGER_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules.sock')
 MANAGER_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control.sock')
-MODULESD_KREQUEST_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'krequest')
 MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'cluster-internal.sock')
 MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor.sock')
 REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote.sock')
 SYSCHECKD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'syscheck')
 WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wdb.sock')
-ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'ar')
 
 
 WAZUH_SOCKETS = {
@@ -51,9 +48,7 @@ WAZUH_SOCKETS = {
     'wazuh-manager-db': [WAZUH_DB_SOCKET_PATH],
     'wazuh-modulesd': [
         MODULESD_WMODULES_SOCKET_PATH,
-        MODULESD_DOWNLOAD_SOCKET_PATH,
         MODULESD_CONTROL_SOCKET_PATH,
-        MODULESD_KREQUEST_SOCKET_PATH
     ],
     'wazuh-manager-modulesd': [
         MANAGER_WMODULES_SOCKET_PATH,
@@ -64,6 +59,5 @@ WAZUH_SOCKETS = {
 
 # These sockets do not exist with default Wazuh configuration
 WAZUH_OPTIONAL_SOCKETS = [
-    MODULESD_KREQUEST_SOCKET_PATH,
     AUTHD_SOCKET_PATH
 ]

--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -15,20 +15,24 @@ QUEUE_RIDS_PATH = os.path.join(WAZUH_PATH, 'queue', 'rids')
 QUEUE_ALERTS_PATH = os.path.join(WAZUH_PATH, 'queue', 'alerts')
 DIFF_PATH_FILE = os.path.join(QUEUE_DIFF_PATH, 'file')
 
-ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'analysis')
+ANALYSISD_ANALISIS_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'engine-api-http.sock')
 ANALYSISD_QUEUE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'queue')
-AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth')
+AUTHD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'auth.sock')
 EXECD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'com')
 LOGCOLLECTOR_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'logcollector')
 MODULESD_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules')
 MODULESD_DOWNLOAD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'download')
 MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
+# The manager renamed these two; the agent keeps the legacy names, so each product
+# needs its own constant.
+MANAGER_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules.sock')
+MANAGER_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control.sock')
 MODULESD_KREQUEST_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'krequest')
-MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_CLUSTER_PATH, 'c-internal.sock')
-MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor')
-REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote')
+MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'cluster-internal.sock')
+MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor.sock')
+REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote.sock')
 SYSCHECKD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'syscheck')
-WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_DB_PATH, 'wdb')
+WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wdb.sock')
 ACTIVE_RESPONSE_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'ar')
 
 
@@ -52,8 +56,8 @@ WAZUH_SOCKETS = {
         MODULESD_KREQUEST_SOCKET_PATH
     ],
     'wazuh-manager-modulesd': [
-        MODULESD_WMODULES_SOCKET_PATH,
-        MODULESD_CONTROL_SOCKET_PATH,
+        MANAGER_WMODULES_SOCKET_PATH,
+        MANAGER_CONTROL_SOCKET_PATH,
     ],
     'wazuh-manager-clusterd': [MODULESD_C_INTERNAL_SOCKET_PATH]
 }

--- a/src/wazuh_testing/utils/sockets.py
+++ b/src/wazuh_testing/utils/sockets.py
@@ -7,7 +7,6 @@ import ipaddress
 
 from wazuh_testing.tools.socket_controller import SocketController
 from wazuh_testing.constants.paths.sockets import QUEUE_SOCKETS_PATH, WAZUH_DB_SOCKET_PATH, \
-                                                  MODULESD_C_INTERNAL_SOCKET_PATH, \
                                                   ACTIVE_RESPONSE_SOCKET_PATH
 from wazuh_testing.utils.network import UDP
 
@@ -23,10 +22,6 @@ def delete_sockets(path=None):
             path = QUEUE_SOCKETS_PATH
             for file in os.listdir(path):
                 os.remove(os.path.join(path, file))
-            if os.path.exists(WAZUH_DB_SOCKET_PATH):
-                os.remove(WAZUH_DB_SOCKET_PATH)
-            if os.path.exists(MODULESD_C_INTERNAL_SOCKET_PATH):
-                os.remove(MODULESD_C_INTERNAL_SOCKET_PATH)
         else:
             for item in path:
                 os.remove(item)

--- a/src/wazuh_testing/utils/sockets.py
+++ b/src/wazuh_testing/utils/sockets.py
@@ -16,16 +16,18 @@ def delete_sockets(path=None):
     Args:
         path (list, optional): Absolute socket path. Default `None`.
     """
-    try:
-        if path is None:
-            path = QUEUE_SOCKETS_PATH
-            for file in os.listdir(path):
-                os.remove(os.path.join(path, file))
-        else:
-            for item in path:
-                os.remove(item)
-    except FileNotFoundError:
-        pass
+    if path is None:
+        try:
+            path = [os.path.join(QUEUE_SOCKETS_PATH, file) for file in os.listdir(QUEUE_SOCKETS_PATH)]
+        except FileNotFoundError:
+            return
+
+    # An absent socket must not stop the removal of the rest.
+    for item in path:
+        try:
+            os.remove(item)
+        except FileNotFoundError:
+            pass
 
 def send_request_socket(query, socket_path=WAZUH_DB_SOCKET_PATH):
     """Send queries request to socket in the argument.

--- a/src/wazuh_testing/utils/sockets.py
+++ b/src/wazuh_testing/utils/sockets.py
@@ -6,8 +6,7 @@ import socket
 import ipaddress
 
 from wazuh_testing.tools.socket_controller import SocketController
-from wazuh_testing.constants.paths.sockets import QUEUE_SOCKETS_PATH, WAZUH_DB_SOCKET_PATH, \
-                                                  ACTIVE_RESPONSE_SOCKET_PATH
+from wazuh_testing.constants.paths.sockets import QUEUE_SOCKETS_PATH, WAZUH_DB_SOCKET_PATH
 from wazuh_testing.utils.network import UDP
 
 
@@ -74,19 +73,6 @@ def send_message_to_syslog_socket(message, port, protocol, manager_address="127.
 
     sock.connect((manager_address, port))
     sock.send(message.encode())
-    sock.close()
-
-
-def send_active_response_message(active_response_command):
-    """Send active response message to `/var/ossec/queue/alerts/ar` socket.
-
-    Args:
-        active_response_command (str): Active response message.
-    """
-    sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-
-    sock.connect(ACTIVE_RESPONSE_SOCKET_PATH)
-    sock.send(f"{active_response_command}".encode())
     sock.close()
 
 


### PR DESCRIPTION
## Description

Scheduled weekly upward merge. Part of #836 (Week #35).

Merges branch `5.0.0` into `5.0.1`.

## Proposed Changes

- Merge `origin/5.0.0` into `5.0.1`.

### Results and Evidence

Merged with one conflict in `CHANGELOG.md`, resolved keeping the 5.0.1 structure (its changelog holds only the v5.0.1 section and links prior versions, so the incoming 5.0.0 entries are intentionally not imported). Incoming changes (6 commits, #834): manager socket constants pointed at `queue/sockets` with the `.sock` suffix, removal of constants for sockets the manager no longer creates, and `delete_sockets` hardening (keeps deleting after an absent socket, no out-of-directory removals).