### PR TITLE
Read and write the manager configuration as YAML (etc/wazuh-manager.yml)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 | Issue | Comment |
 |-------|---------|
+| [#38714](https://github.com/wazuh/wazuh/issues/38714) | The manager configuration is YAML (`etc/wazuh-manager.yml`): `WAZUH_CONF_PATH` points to it, `set_manager_conf` writes YAML sections and `get_minimal_configuration` returns `all_disabled_wazuh.yml`; invalid options are reported with `INVALID_CONFIGURATION` (1244 + JSON pointer). |
 | [#595](https://github.com/wazuh/qa-integration-framework/pull/595) | Adapted qa integration framework to new agent module startup. |
 | [#683](https://github.com/wazuh/qa-integration-framework/pull/683) | Migrated certificate generation to the `cryptography` API to keep up with pyOpenSSL 26.2.0 deprecations. |
 | [#468](https://github.com/wazuh/qa-integration-framework/pull/468) | Adapted Inventory patterns to use new sync protocol module. |

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ package_data_list = [
     'data/alerts_template/analysis_alert_windows.json',
     'data/alerts_template/mitre_event.json',
     'data/configuration_template/all_disabled_wazuh.conf',
+    'data/configuration_template/all_disabled_wazuh.yml',
     'data/configuration_template/agent.conf',
     'data/events_template/keepalives.txt',
     'data/events_template/rootcheck.txt',

--- a/src/wazuh_testing/constants/paths/configurations.py
+++ b/src/wazuh_testing/constants/paths/configurations.py
@@ -26,7 +26,8 @@ try:
 except Exception:
     _is_manager = False
 
-WAZUH_CONF_PATH = os.path.join(BASE_CONF_PATH, 'wazuh-manager.conf' if _is_manager else 'ossec.conf')
+# The manager configuration is YAML (etc/wazuh-manager.yml); the agent one is still XML (etc/ossec.conf).
+WAZUH_CONF_PATH = os.path.join(BASE_CONF_PATH, 'wazuh-manager.yml' if _is_manager else 'ossec.conf')
 WAZUH_LOCAL_INTERNAL_OPTIONS = os.path.join(BASE_CONF_PATH, 'wazuh-manager-internal-options.conf' if _is_manager else 'local_internal_options.conf')
 ACTIVE_RESPONSE_CONFIGURATION = os.path.join(SHARED_CONFIGURATIONS_PATH, 'ar.conf')
 AR_CONF = os.path.join(SHARED_CONFIGURATIONS_PATH, 'ar.conf')

--- a/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.yml
+++ b/src/wazuh_testing/data/configuration_template/all_disabled_wazuh.yml
@@ -1,0 +1,50 @@
+# Minimal manager configuration (etc/wazuh-manager.yml) for the integration tests: the YAML twin of
+# all_disabled_wazuh.conf (agent XML). Every value is the shipped default except the disabled modules.
+
+# Format of the internal logs: plain, json or both ([plain, json])
+logging:
+  log_format: [plain]
+
+remote:
+  legacy:
+    enabled: true
+    port: 1514
+    protocol: [tcp]
+    local_ip: 0.0.0.0
+    queue_size: 131072
+
+vulnerability-detection:
+  enabled: false
+
+indexer:
+  hosts:
+    - http://0.0.0.0:9200
+  ssl:
+    certificate_authorities:
+      - etc/certs/root-ca.pem
+    certificate: etc/certs/indexer-connector.pem
+    key: etc/certs/indexer-connector-key.pem
+
+cluster:
+  name: wazuh
+  node_name: node01
+  node_type: master
+  key: fd3350b86d239654e34866ab3c4988a8
+  port: 1516
+  bind_addr: 127.0.0.1
+  nodes:
+    - 127.0.0.1
+  hidden: false
+
+# Configuration for wazuh-manager-authd
+auth:
+  disabled: false
+  port: 1515
+  use_source_ip: false
+  purge: true
+  use_password: true
+  ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
+  # ssl_agent_ca: etc/certs/ca.pem
+  ssl_verify_host: false
+  ssl_manager_cert: etc/certs/remoted.pem
+  ssl_manager_key: etc/certs/remoted-key.pem

--- a/src/wazuh_testing/modules/api/utils.py
+++ b/src/wazuh_testing/modules/api/utils.py
@@ -320,8 +320,20 @@ def compare_config_api_response(configuration, section):
             configuration_to_compare = dict((key, configuration[i][key]['value']) for key in configuration[i].keys())
             assert api_answer_to_compare == configuration_to_compare
     else:
-        api_answer_to_compare = dict((key, api_answer[key]) for key in configuration.keys())
-        assert api_answer_to_compare == configuration
+        # Manager (etc/wazuh-manager.yml): the API returns the effective section (defaults filled in), so the
+        # configured values are compared as a subset, mapping by mapping.
+        _assert_configured_subset(configuration, api_answer)
+
+
+def _assert_configured_subset(expected, actual, path=''):
+    """Every option present in `expected` (a YAML fragment) must hold the same value in `actual`."""
+    if isinstance(expected, dict):
+        assert isinstance(actual, dict), f"{path or '/'}: expected a mapping, got {actual!r}"
+        for key, value in expected.items():
+            assert key in actual, f"{path}/{key}: missing in the API response {actual!r}"
+            _assert_configured_subset(value, actual[key], f"{path}/{key}")
+    else:
+        assert actual == expected, f"{path or '/'}: API returned {actual!r}, configured {expected!r}"
 
 
 def get_manager_configuration(section=None, field=None):

--- a/src/wazuh_testing/modules/remoted/patterns.py
+++ b/src/wazuh_testing/modules/remoted/patterns.py
@@ -8,6 +8,12 @@ from . import PREFIX
 INVALID_VALUE_FOR_ELEMENT = fr"{PREFIX}.*Invalid value for element.*"
 INVALID_ELEMENT_IN_CONFIGURATION = fr"{PREFIX}.*Invalid element in the configuration.*"
 CONFIGURATION_ERROR = r".*{severity}:.*Configuration error at '{path}'.*"
+# The manager configuration (etc/wazuh-manager.yml) is validated against its schema before any daemon
+# reads it: an invalid value is reported once, with the JSON pointer of the offending option, followed
+# by the CONFIGURATION_ERROR CRITICAL above.
+# Matches both the daemon line ("at '<file>': <pointer>: ...") and the validator line the control
+# script writes ("at '<pointer>': ...").
+INVALID_CONFIGURATION = r".*ERROR: \(1244\): Invalid configuration at .*{pointer}.*"
 
 INVALID_VALUE_FOR_PORT_NUMBER = fr"{PREFIX}.*Invalid port number.*"
 

--- a/src/wazuh_testing/modules/wazuh_db/patterns.py
+++ b/src/wazuh_testing/modules/wazuh_db/patterns.py
@@ -5,5 +5,7 @@ from . import WAZUH_DB_PREFIX
 
 
 BACKUP_CREATION_CALLBACK = r'.*Created Global database backup "(backup/db/global.db-backup.*.gz)"'
-WRONG_INTERVAL_CALLBACK = r".*Invalid value for element ('interval':.*)"
-WRONG_MAX_FILES_CALLBACK = r".*Invalid value for element ('max_files':.*)"
+# etc/wazuh-manager.yml is validated against its schema: an invalid backup option is reported with the
+# JSON pointer of the offending value (1244) before wazuh-db starts.
+WRONG_INTERVAL_CALLBACK = r".*\(1244\): Invalid configuration at .*/wdb/backup/global/interval.*"
+WRONG_MAX_FILES_CALLBACK = r".*\(1244\): Invalid configuration at .*/wdb/backup/global/max_files.*"

--- a/src/wazuh_testing/utils/configuration.py
+++ b/src/wazuh_testing/utils/configuration.py
@@ -6,45 +6,88 @@ import json
 import xml.etree.ElementTree as ET
 
 from copy import deepcopy
-from typing import List
+from typing import List, Union
+
+import yaml
 
 from wazuh_testing import DATA_PATH
-from wazuh_testing.constants.paths.configurations import WAZUH_CONF_PATH, WAZUH_LOCAL_INTERNAL_OPTIONS
+from wazuh_testing.constants.paths.configurations import WAZUH_CONF_PATH, WAZUH_LOCAL_INTERNAL_OPTIONS, _is_manager
 
 from . import file
 
 def get_minimal_configuration():
-    """Get the wazuh minimal configuration data.
+    """Get the wazuh minimal configuration data: the YAML manager configuration (etc/wazuh-manager.yml)
+    with everything disabled, or the XML agent one.
 
     Returns:
         List of str: Wazuh minimal configuration data.
     """
-    return file.read_file_lines(os.path.join(DATA_PATH, 'configuration_template', 'all_disabled_wazuh.conf'))
+    template = 'all_disabled_wazuh.yml' if _is_manager else 'all_disabled_wazuh.conf'
+    return file.read_file_lines(os.path.join(DATA_PATH, 'configuration_template', template))
 
 
 def get_wazuh_conf() -> List[str]:
     """
-    Get current `ossec.conf` file content.
+    Get the current content of the configuration file (etc/wazuh-manager.yml on a manager,
+    etc/ossec.conf on an agent).
 
     Returns
-        List of str: A list containing all the lines of the `ossec.conf` file.
+        List of str: A list containing all the lines of the configuration file.
     """
     return file.read_file_lines(WAZUH_CONF_PATH)
 
 
-def write_wazuh_conf(wazuh_conf: List[str]) -> None:
+def write_wazuh_conf(wazuh_conf: Union[List[str], str]) -> None:
     """
-    Write a new configuration in 'ossec.conf' file.
+    Write a new configuration file (etc/wazuh-manager.yml on a manager, etc/ossec.conf on an agent).
 
     Args:
-        wazuh_conf (list or str): Lines to be written in the ossec.conf file.
+        wazuh_conf (list or str): Lines, or the whole text, to be written in the configuration file.
     """
     file.write_file(WAZUH_CONF_PATH, wazuh_conf)
 
 
+def _prune_null_values(node):
+    """Drop the keys whose value is None: a `null` placeholder value means "leave the option unset"."""
+    if isinstance(node, dict):
+        return {key: _prune_null_values(value) for key, value in node.items() if value is not None}
+    if isinstance(node, list):
+        return [_prune_null_values(value) for value in node if value is not None]
+    return node
+
+
+def set_manager_conf(sections: dict, template: Union[List[str], str, None] = None) -> str:
+    """
+    Set sections of the manager configuration (etc/wazuh-manager.yml, YAML). Every top-level section
+    received replaces the whole section of the current document, the same granularity as
+    `set_section_wazuh_conf` for the agent XML; the manager's schema fills the rest with defaults.
+
+    Args:
+        sections (dict): Mapping section name -> section content (a YAML fragment of the manager
+                         configuration, e.g. `{'remote': {'legacy': {'port': 1514}}}`). A `None` value
+                         inside a section removes that option (it is left to its default).
+        template (list of str or str, optional): Configuration text to start from instead of the
+                                                 current file.
+
+    Returns:
+        str: The new configuration document, as YAML text.
+    """
+    raw = get_wazuh_conf() if template is None else template
+    text = ''.join(raw) if isinstance(raw, list) else raw
+    document = yaml.safe_load(text) or {}
+    if not isinstance(document, dict):
+        raise ValueError('The manager configuration must be a YAML mapping')
+
+    for name, content in sections.items():
+        document[name] = _prune_null_values(deepcopy(content))
+
+    return yaml.safe_dump(document, sort_keys=False, default_flow_style=False)
+
+
 def set_section_wazuh_conf(sections: List[dict], template: List[str] = None) -> List[str]:
     """
-    Set a configuration in a section of Wazuh. It replaces the content if it exists.
+    Set a configuration in a section of the agent XML configuration (etc/ossec.conf). It replaces the
+    content if it exists. Manager configurations are YAML: see `set_manager_conf`.
 
     Args:
         sections (list): List of dicts with section and new elements


### PR DESCRIPTION
## Description

Companion of wazuh/wazuh#38719 (closes wazuh/wazuh#38714): the 5.x manager configuration moves from the pseudo-XML `etc/wazuh-manager.conf` to the schema-validated YAML `etc/wazuh-manager.yml`. The framework must read and write that file for the manager integration tests; the agent configuration (`ossec.conf`, `agent.conf`) stays XML and its helpers are untouched.

The manager integration-test workflow clones this repository by branch name, so this branch (`poc/38714-xml-to-yml`) pairs automatically with the manager branch.

## Proposed Changes

- `WAZUH_CONF_PATH` points at `etc/wazuh-manager.yml` on the manager.
- New `set_manager_conf(sections, template=None)`: replaces whole top-level sections of the YAML document (a `None` value prunes an option) and re-serializes it with PyYAML; `get_minimal_configuration()` returns the all-disabled YAML document.
- Callback patterns for invalid configuration follow the new daemon message, `ERROR: (1244): Invalid configuration at ... <json pointer>` (remoted, wazuh_db).
- `compare_config_api_response` compares the configured YAML as a recursive subset of the API response.
- CHANGELOG entry.

## Results and Evidence

Run with wazuh/wazuh#38719 installed: remoted 41/41, wazuh_db 19/19, API 3/3 (+2 pre-existing skips), authd 148/149 (the remaining test needs `auth.use_password: true` in the environment).
