### PR TITLE
Remove monitord references from the manager daemon and socket lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 | Issue | Comment |
 |-------|---------|
 | [#585](https://github.com/wazuh/qa-integration-framework/pull/585) | Removed wazuh-execd from manager daemon lists. |
+| [#835](https://github.com/wazuh/qa-integration-framework/pull/835) | Removed `wazuh-manager-monitord` from the manager daemon list. |
 | [#834](https://github.com/wazuh/qa-integration-framework/pull/834) | Removed the socket constants for sockets the manager no longer creates. |
 | [#470](https://github.com/wazuh/qa-integration-framework/pull/470) | Removed Wazuh Manager deprecated daemons and CLI tools. |
 | [#444](https://github.com/wazuh/qa-integration-framework/pull/444) | Removed agent-auth references. |

--- a/src/wazuh_testing/constants/daemons.py
+++ b/src/wazuh_testing/constants/daemons.py
@@ -13,7 +13,6 @@ API_DAEMON = 'wazuh-manager-apid'
 AUTHD_DAEMON = 'wazuh-manager-authd'
 CLUSTER_DAEMON = 'wazuh-manager-clusterd'
 MODULES_DAEMON = 'wazuh-manager-modulesd'
-MONITOR_DAEMON = 'wazuh-manager-monitord'
 REMOTE_DAEMON = 'wazuh-manager-remoted'
 WAZUH_DB_DAEMON = 'wazuh-manager-db'
 
@@ -27,7 +26,6 @@ WAZUH_MANAGER_DAEMONS = [ANALYSISD_DAEMON,
                          API_DAEMON,
                          CLUSTER_DAEMON,
                          MODULES_DAEMON,
-                         MONITOR_DAEMON,
                          REMOTE_DAEMON,
                          WAZUH_DB_DAEMON]
 

--- a/src/wazuh_testing/constants/paths/sockets.py
+++ b/src/wazuh_testing/constants/paths/sockets.py
@@ -27,7 +27,6 @@ MODULESD_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control')
 MANAGER_WMODULES_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wmodules.sock')
 MANAGER_CONTROL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'control.sock')
 MODULESD_C_INTERNAL_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'cluster-internal.sock')
-MONITORD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'monitor.sock')
 REMOTED_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'remote.sock')
 SYSCHECKD_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'syscheck')
 WAZUH_DB_SOCKET_PATH = os.path.join(QUEUE_SOCKETS_PATH, 'wdb.sock')
@@ -42,7 +41,6 @@ WAZUH_SOCKETS = {
     'wazuh-manager-authd': [AUTHD_SOCKET_PATH],
     'wazuh-execd': [EXECD_SOCKET_PATH],
     'wazuh-logcollector': [LOGCOLLECTOR_SOCKET_PATH],
-    'wazuh-manager-monitord': [MONITORD_SOCKET_PATH],
     'wazuh-manager-remoted': [REMOTED_SOCKET_PATH],
     'wazuh-syscheckd': [SYSCHECKD_SOCKET_PATH],
     'wazuh-manager-db': [WAZUH_DB_SOCKET_PATH],

--- a/src/wazuh_testing/data/alerts_template/mitre_event.json
+++ b/src/wazuh_testing/data/alerts_template/mitre_event.json
@@ -332,7 +332,7 @@
       "title": "The Location Schema",
       "default": "",
       "examples": [
-        "wazuh-manager-monitord"
+        "wazuh-manager-modulesd"
       ],
       "pattern": "^(.*)$"
     }

--- a/src/wazuh_testing/modules/monitord/__init__.py
+++ b/src/wazuh_testing/modules/monitord/__init__.py
@@ -1,5 +1,0 @@
-# Copyright (C) 2015-2023, Wazuh Inc.
-# Created by Wazuh, Inc. <info@wazuh.com>.
-# This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
-
-PREFIX = r'.*wazuh-manager-monitord.*'

--- a/src/wazuh_testing/modules/monitord/configuration.py
+++ b/src/wazuh_testing/modules/monitord/configuration.py
@@ -2,5 +2,9 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is free software; you can redistribute it and/or modify it under the terms of GPLv2
 
-# Internal configuration options
+# Internal configuration options.
+#
+# AGENT ONLY. The agent keeps the `monitord.*` namespace for its own log rotation, read by
+# wazuh-agentd. The manager's equivalent moved to `wazuh_modules.manager_task_log_*` when its
+# rotation became a Task Manager job; a manager test must use those names, not these.
 MONITORD_ROTATE_LOG = 'monitord.rotate_log'


### PR DESCRIPTION
## Description
The manager no longer runs `wazuh-manager-monitord`: its log rotation responsibility moved to the Task Manager (`wazuh_modules.manager_task_log_*`). The framework still declared the daemon, its socket, and a monitord log prefix, so manager tests could wait on a process and a socket that are never created. This PR removes those dead references and documents that the remaining `monitord.*` internal options are agent-only.

Related to wazuh/wazuh#38589.

## Proposed Changes
- Remove `MONITOR_DAEMON` and drop it from `WAZUH_MANAGER_DAEMONS` in [daemons.py](src/wazuh_testing/constants/daemons.py).
- Remove `MONITORD_SOCKET_PATH` and its `wazuh-manager-monitord` entry from the `WAZUH_SOCKETS` map in [sockets.py](src/wazuh_testing/constants/paths/sockets.py).
- Empty [modules/monitord/__init__.py](src/wazuh_testing/modules/monitord/__init__.py), removing the `PREFIX` log regex for the manager monitord daemon.
- Document in [modules/monitord/configuration.py](src/wazuh_testing/modules/monitord/configuration.py) that `MONITORD_ROTATE_LOG` and the rest of the `monitord.*` internal options are agent-only, and that manager tests must use `wazuh_modules.manager_task_log_*` instead.
- Update the `location` example in the [mitre_event.json](src/wazuh_testing/data/alerts_template/mitre_event.json) alert template from `wazuh-manager-monitord` to `wazuh-manager-modulesd`.
- Add the corresponding CHANGELOG entry.

