### PR TITLE
Bump version to 4.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.10.6]
+
 ## [4.10.5]
 
 ## [4.10.4]

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ def get_install_requires() -> List[str]:
 
 setup(
     name='wazuh_testing',
-    version='4.10.5',
+    version='4.10.6',
     description='Wazuh testing utilities to help programmers automate tests',
     url='https://github.com/wazuh',
     author='Wazuh',


### PR DESCRIPTION
## Description

Bump the `4.10.6` branch from `4.10.5` to `4.10.6`, including an empty `[4.10.6]` section in `CHANGELOG.md` ready to receive entries.

Closes #852.